### PR TITLE
Implement basic support for Firebase Remote Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 <img src="logo.png" align="right" />
-
 # QtFirebase
 An effort to bring the Firebase C++ API to Qt 5
 
@@ -23,7 +22,7 @@ Analytics                 |libanalytics.a       |✓|✓
 ~~Realtime Database~~	        |~~libdatabase.a~~      | |
 ~~Invites and Dynamic Links~~	|~~libinvites.a~~       | |
 ~~Cloud Messaging~~	          |~~libmessaging.a~~     | |
-~~Remote Config~~	            |~~libremote_config.a~~ | |
+~~Remote Config~~	            |~~libremote_config.a~~ |✓|✓
 ~~Storage~~	                  |~~libstorage.a~~       | |
 
 Tested with Firebase C++ SDK
@@ -79,5 +78,5 @@ Possible ways of giving support
 # In the wild
 The following is a list of software that uses QtFirebase
 * [Hammer Bees](http://blackgrain.dk/games/hammerbees/) (Casual game, [Android](https://play.google.com/store/apps/details?id=com.bitkompot.android.hammerbees.ad), [iOS](https://itunes.apple.com/us/app/hammer-bees-free/id1164069527?ls=1&mt=8))
-* [Dead Ascend](http://blackgrain.dk/games/deadascend/) (Open Source, Adventure game, [Android](https://play.google.com/store/apps/details?id=com.blackgrain.android.deadascend.ad), [iOS](https://itunes.apple.com/us/app/dead-ascend/id1197443665?ls=1&mt=8))
+* [Dead Ascend](http://blackgrain.dk/games/deadascend/) (Open Source, Aventure game, [Android](https://play.google.com/store/apps/details?id=com.blackgrain.android.deadascend.ad), [iOS](https://itunes.apple.com/us/app/dead-ascend/id1197443665?ls=1&mt=8))
 * \<your awesome project\>

--- a/fake/src/qtfirebaseremoteconfig.h
+++ b/fake/src/qtfirebaseremoteconfig.h
@@ -1,0 +1,65 @@
+#ifndef QTFIREBASEREMOTECONFIG_H
+#define QTFIREBASEREMOTECONFIG_H
+
+#include <QObject>
+
+#ifdef QTFIREBASE_BUILD_REMOTE_CONFIG
+
+#include "src/qtfirebase.h"
+#include <QDebug>
+
+#if defined(qFirebaseRemoteConfig)
+#undef qFirebaseRemoteConfig
+#endif
+#define qFirebaseRemoteConfig (static_cast<QtFirebaseRemoteConfig *>(QtFirebaseRemoteConfig::instance()))
+
+class QtFirebaseRemoteConfig : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
+    Q_PROPERTY(bool loaded READ loaded NOTIFY loadedChanged)
+public:
+    enum Error
+    {
+        kFetchFailureReasonInvalid,
+        kFetchFailureReasonThrottled,
+        kFetchFailureReasonError,
+    };
+    Q_ENUM(Error)
+
+    explicit QtFirebaseRemoteConfig(QObject *parent = 0){}
+    ~QtFirebaseRemoteConfig() {}
+    QtFirebaseRemoteConfig *instance() {
+            if(self == 0) {
+                self = new QtFirebaseRemoteConfig(0);
+                qDebug() << self << "::instance" << "singleton";
+            }
+            return self;
+        }
+    bool checkInstance(const char *function);
+
+    bool ready(){return false;}
+    void setReady(bool ready){Q_UNUSED(ready)}
+
+    bool loaded(){return false;}
+    void setLoaded(bool loaded){Q_UNUSED(loaded)}
+
+    void addParameter(const QString &name, long long defaultValue){Q_UNUSED(name); Q_UNUSED(defaultValue);}
+    void addParameter(const QString &name, double defaultValue){Q_UNUSED(name); Q_UNUSED(defaultValue);}
+    void addParameter(const QString &name, const QString& defaultValue){Q_UNUSED(name); Q_UNUSED(defaultValue);}
+    void addParameter(const QString &name, bool defaultValue){Q_UNUSED(name); Q_UNUSED(defaultValue);}
+    QVariant getParameterValue(const QString &name) const {Q_UNUSED(name);return QVariant();}
+    void requestConfig(long long cacheExpirationInSeconds = 0){Q_UNUSED(cacheExpirationInSeconds);}
+signals:
+    void readyChanged();
+    void loadedChanged();
+    void error(Error code, QString message);
+
+private:
+    static QtFirebaseRemoteConfig *self;
+    Q_DISABLE_COPY(QtFirebaseRemoteConfig)
+};
+
+#endif //QTFIREBASE_BUILD_REMOTE_CONFIG
+
+#endif // QTFIREBASEREMOTECONFIG_H

--- a/qtfirebase.pri
+++ b/qtfirebase.pri
@@ -17,6 +17,11 @@ contains(QTFIREBASE_CONFIG,"admob") {
     DEFINES += QTFIREBASE_BUILD_ADMOB
 }
 
+contains(QTFIREBASE_CONFIG,"remote_config") {
+    DEFINES += QTFIREBASE_BUILD_REMOTE_CONFIG
+}
+
+
 DISTFILES += \
     $$PWD/LICENSE
 

--- a/qtfirebase_dummy.pri
+++ b/qtfirebase_dummy.pri
@@ -26,3 +26,8 @@ contains(DEFINES,QTFIREBASE_BUILD_ADMOB) {
     HEADERS += $$QTFIREBASE_FAKE_PATH/src/qtfirebaseadmob.h
 }
 
+# Remote Config
+contains(DEFINES,QTFIREBASE_BUILD_REMOTE_CONFIG) {
+    HEADERS += $$QTFIREBASE_FAKE_PATH/src/qtfirebaseremoteconfig.h
+}
+

--- a/qtfirebase_register.h
+++ b/qtfirebase_register.h
@@ -26,6 +26,17 @@
 
 # endif // QTFIREBASE_BUILD_ADMOB
 
+
+#if defined(QTFIREBASE_BUILD_ALL) || defined(QTFIREBASE_BUILD_REMOTE_CONFIG)
+
+#if defined(QTFIREBASE_FAKE_BUILD)
+    #include "fake/src/qtfirebaseremoteconfig.h"
+#else
+    #include "src/qtfirebaseremoteconfig.h"
+#endif
+
+# endif // QTFIREBASE_BUILD_REMOTE_CONFIG
+
 static void registerQtFirebase() {
 
     #if defined(QTFIREBASE_BUILD_ALL) || defined(QTFIREBASE_BUILD_ANALYTICS)
@@ -39,6 +50,9 @@ static void registerQtFirebase() {
     qmlRegisterType<QtFirebaseAdMobInterstitial>("QtFirebase", 1, 0, "AdMobInterstitial");
     #endif
 
+    #if defined(QTFIREBASE_BUILD_ALL) || defined(QTFIREBASE_BUILD_REMOTE_CONFIG)
+    qmlRegisterType<QtFirebaseRemoteConfig>("QtFirebase", 1, 0, "RemoteConfig");
+    #endif
 }
 
 Q_COREAPP_STARTUP_FUNCTION(registerQtFirebase)

--- a/qtfirebase_target.pri
+++ b/qtfirebase_target.pri
@@ -132,5 +132,24 @@ contains(DEFINES,QTFIREBASE_BUILD_ADMOB) {
     LIBS += -L$$QTFIREBASE_SDK_LIBS_PATH -ladmob
 }
 
+# RemoteConfig
+contains(DEFINES,QTFIREBASE_BUILD_REMOTE_CONFIG) {
+    message( "QtFirebase including RemoteConfig" )
+
+    #TODO remote config on ios
+    ios: {
+        message( "QtFirebase RemoteConfig not tested on ios" )
+        LIBS += \
+            -F$$QTFIREBASE_FRAMEWORKS_ROOT/RemoteConfig/Frameworks \
+            -framework RemoteConfig \
+    }
+
+    HEADERS += $$PWD/src/qtfirebaseremoteconfig.h
+    SOURCES += $$PWD/src/qtfirebaseremoteconfig.cpp
+
+    LIBS += -L$$QTFIREBASE_SDK_LIBS_PATH -lremote_config
+}
+
+
 LIBS += -L$$QTFIREBASE_SDK_LIBS_PATH -lapp
 

--- a/src/qtfirebase.cpp
+++ b/src/qtfirebase.cpp
@@ -138,7 +138,6 @@ void QtFirebase::processEvents()
             if(_futureMap.remove(i.key()) >= 1)
                 qDebug() << self << "::processEvents" << "removed future event" << i.key();
             emit futureEvent(i.key(),i.value());
-
             // To easen events up:
             //break;
         }

--- a/src/qtfirebase_plugin.cpp
+++ b/src/qtfirebase_plugin.cpp
@@ -8,6 +8,11 @@
 #include "src/qtfirebaseadmob.h"
 # endif // QTFIREBASE_BUILD_ADMOB
 
+
+#if defined(QTFIREBASE_BUILD_ALL) || defined(QTFIREBASE_BUILD_REMOTE_CONFIG)
+#include "src/qtfirebaseremoteconfig.h"
+# endif // QTFIREBASE_BUILD_REMOTE_CONFIG
+
 #include <qqml.h>
 
 void QtFirebasePlugin::registerTypes(const char *uri)
@@ -23,6 +28,10 @@ void QtFirebasePlugin::registerTypes(const char *uri)
     qmlRegisterType<QtFirebaseAdMobRequest>(uri, 1, 0, "AdMobRequest");
     qmlRegisterType<QtFirebaseAdMobBanner>(uri, 1, 0, "AdMobBanner");
     qmlRegisterType<QtFirebaseAdMobInterstitial>(uri, 1, 0, "AdMobInterstitial");
+    #endif
+
+    #if defined(QTFIREBASE_BUILD_ALL) || defined(QTFIREBASE_BUILD_REMOTE_CONFIG)
+    qmlRegisterType<QtFirebaseRemoteConfig>(uri, 1, 0, "RemoteConfig");
     #endif
 }
 

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -1,0 +1,302 @@
+#include "qtfirebaseremoteconfig.h"
+#include <memory>
+namespace remote_config = ::firebase::remote_config;
+
+QtFirebaseRemoteConfig *QtFirebaseRemoteConfig::self = 0;
+
+QtFirebaseRemoteConfig::QtFirebaseRemoteConfig(QObject *parent) :
+    QObject(parent),
+    _ready(false),
+    _initializing(false),
+    _loaded(false),
+    __appId(nullptr)
+{
+    __QTFIREBASE_ID = QString().sprintf("%8p", this);
+    if(self == 0)
+    {
+        self = this;
+        qDebug() << self << "::QtFirebaseRemoteConfig" << "singleton";
+    }
+
+    if(qFirebase->ready())
+    {
+        //Call init outside of constructor, otherwise signal readyChanged not emited
+        QTimer::singleShot(500, this, SLOT(init()));
+    }
+    else
+    {
+        connect(qFirebase,&QtFirebase::readyChanged, this, &QtFirebaseRemoteConfig::init);
+        qFirebase->requestInit();
+    }
+    connect(qFirebase,&QtFirebase::futureEvent, this, &QtFirebaseRemoteConfig::onFutureEvent);
+}
+
+bool QtFirebaseRemoteConfig::checkInstance(const char *function)
+{
+    bool b = (QtFirebaseRemoteConfig::self != 0);
+    if(!b) qWarning("QtFirebaseRemoteConfig::%s:", function);
+    return b;
+}
+
+void QtFirebaseRemoteConfig::addParameterInternal(const QString &name, const QVariant &defaultValue)
+{
+    _parameters[name] = defaultValue;
+}
+
+QVariant QtFirebaseRemoteConfig::getParameterValue(const QString &name) const
+{
+
+    if(_parameters.contains(name))
+    {
+        return _parameters[name];
+    }
+    return _parameters[name];
+}
+
+bool QtFirebaseRemoteConfig::ready()
+{
+    return _ready;
+}
+
+void QtFirebaseRemoteConfig::setReady(bool ready)
+{
+    qDebug() << this << "::setReady" << ready<<_ready;
+    if (_ready != ready) {
+        _ready = ready;
+        qDebug() << this << "::setReady" << "emit ready";
+        emit readyChanged();
+    }
+}
+
+bool QtFirebaseRemoteConfig::loaded()
+{
+    return _loaded;
+}
+
+void QtFirebaseRemoteConfig::setLoaded(bool loaded)
+{
+    if(_loaded != loaded) {
+        _loaded = loaded;
+        qDebug() << this << "::setLoaded" << _loaded;
+        emit loadedChanged();
+    }
+}
+
+void QtFirebaseRemoteConfig::addParameter(const QString &name, long long defaultValue)
+{
+    addParameterInternal(name, defaultValue);
+}
+
+void QtFirebaseRemoteConfig::addParameter(const QString &name, double defaultValue)
+{
+    addParameterInternal(name, defaultValue);
+}
+
+void QtFirebaseRemoteConfig::addParameter(const QString &name, const QString &defaultValue)
+{
+    addParameterInternal(name, defaultValue);
+}
+
+void QtFirebaseRemoteConfig::addParameter(const QString &name, bool defaultValue)
+{
+    addParameterInternal(name, defaultValue);
+}
+
+void QtFirebaseRemoteConfig::init()
+{
+    if(!qFirebase->ready()) {
+        qDebug() << self << "::init" << "base not ready";
+        return;
+    }
+
+    if(!_ready && !_initializing) {
+        _initializing = true;
+
+        remote_config::Initialize(*qFirebase->firebaseApp());
+        qDebug() << self << "::init" << "native initialized";
+        _initializing = false;
+        setReady(true);
+    }
+}
+
+void QtFirebaseRemoteConfig::onFutureEvent(QString eventId, firebase::FutureBase future)
+{
+    qDebug()<<"QtFirebaseRemoteConfig"<<"::onFutureEvent"<<eventId;
+    if(!eventId.startsWith(__QTFIREBASE_ID))
+        return;
+
+    if(eventId == __QTFIREBASE_ID+".config.fetch")
+    {
+        if(future.status() != firebase::kFutureStatusComplete)
+        {
+            qDebug() << this << "::onFutureEvent initializing failed." << "ERROR: Action failed with error code and message: " << future.Error() << future.ErrorMessage();
+            _initializing = false;
+            return;
+        }
+        qDebug() << this << "::onFutureEvent initialized";
+        _initializing = false;
+
+        bool activate_result = remote_config::ActivateFetched();
+
+        qDebug()<<QString("ActivateFetched %1").arg(activate_result ? "succeeded" : "failed");
+
+        const remote_config::ConfigInfo& info = remote_config::GetInfo();
+
+        qDebug()<<QString("Info last_fetch_time_ms=%1 fetch_status=%2 failure_reason=%3")
+                .arg(QString::number(info.fetch_time))
+                .arg(info.last_fetch_status)
+                .arg(info.last_fetch_failure_reason);
+
+        ParametersMap parametersUpdated;
+        for(ParametersMap::const_iterator it = _parameters.begin(); it!=_parameters.end();++it)
+        {
+            const QVariant& value = it.value();
+
+            Q_ASSERT(value.type() == QVariant::Bool ||
+                     value.type() == QVariant::LongLong ||
+                     value.type() == QVariant::Double ||
+                     value.type() == QVariant::String);
+
+            if(value.type() == QVariant::Bool)
+            {
+                parametersUpdated[it.key()] = remote_config::GetBoolean(it.key().toUtf8().constData());
+            }
+            else if(value.type() == QVariant::LongLong)
+            {
+                parametersUpdated[it.key()] = remote_config::GetLong(it.key().toUtf8().constData());
+            }
+            else if(value.type() == QVariant::Double)
+            {
+                parametersUpdated[it.key()] = remote_config::GetDouble(it.key().toUtf8().constData());
+            }
+            else if(value.type() == QVariant::String)
+            {
+                //Cause crash
+                //std::string result = remote_config::GetString(it.key().toUtf8().constData());
+                //parametersUpdated[it.key()] = QString(result.c_str());
+
+                std::vector<unsigned char> out = remote_config::GetData(it.key().toUtf8().constData());
+                QByteArray data;
+                for (size_t i = 0; i < out.size(); ++i)
+                {
+                    data.append(out[i]);
+                }
+                parametersUpdated[it.key()] = QString(data);
+            }
+        }
+
+
+        _parameters = parametersUpdated;
+        //SDK code for data (char array) container
+        /*{
+          std::vector<unsigned char> result = remote_config::GetData("TestData");
+          for (size_t i = 0; i < result.size(); ++i) {
+            const unsigned char value = result[i];
+            printf("TestData[%d] = 0x%02x", i, value);
+          }
+        }*/
+
+        //SDK code to print out the keys
+        /*std::vector<std::string> keys = remote_config::GetKeys();
+        qDebug()<<"QtFirebaseRemoteConfig GetKeys:";
+        for (auto s = keys.begin(); s != keys.end(); ++s)
+        {
+            qDebug()<<s->c_str();
+        }
+        keys = remote_config::GetKeysByPrefix("TestD");
+        printf("GetKeysByPrefix(\"TestD\"):");
+        for (auto s = keys.begin(); s != keys.end(); ++s) {
+          printf("  %s", s->c_str());
+        }*/
+
+        future.Release();
+
+        if(info.last_fetch_status == remote_config::kLastFetchStatusSuccess)
+        {
+            setLoaded(true);
+        }
+        else
+        {
+            if(info.last_fetch_failure_reason == remote_config::kFetchFailureReasonInvalid)
+            {
+                emit error(kFetchFailureReasonInvalid, "The fetch has not yet failed.");
+            }
+            else if(info.last_fetch_failure_reason == remote_config::kFetchFailureReasonThrottled)
+            {
+                emit error(kFetchFailureReasonThrottled, "Throttled by the server. You are sending too many fetch requests in too short a time.");
+            }
+            else
+            {
+                emit error(kFetchFailureReasonError, "Failure reason is unknown");
+            }
+        }
+    }
+}
+
+void QtFirebaseRemoteConfig::requestConfig(long long cacheExpirationInSeconds)
+{
+    _loaded = false;
+    if(_parameters.size() == 0)
+        return;
+
+    qDebug()<<"QtFirebaseRemoteConfig::requestConfig with expirationtime"<<cacheExpirationInSeconds<<"sec";
+
+    std::unique_ptr<remote_config::ConfigKeyValueVariant[]> defaults(
+                new remote_config::ConfigKeyValueVariant[_parameters.size()]);
+
+
+    uint cnt = 0;
+    for(ParametersMap::const_iterator it = _parameters.begin(); it!=_parameters.end();++it)
+    {
+        const QVariant& value = it.value();
+
+        Q_ASSERT(value.type() == QVariant::Bool ||
+                 value.type() == QVariant::LongLong ||
+                 value.type() == QVariant::Double ||
+                 value.type() == QVariant::String);
+
+
+        if(value.type() == QVariant::Bool)
+        {
+            defaults[cnt] = remote_config::ConfigKeyValueVariant{it.key().toUtf8().constData(),
+                                                                 value.toBool()};
+        }
+        else if(value.type() == QVariant::LongLong)
+        {
+            defaults[cnt] = remote_config::ConfigKeyValueVariant{it.key().toUtf8().constData(),
+                                                                 value.toLongLong()};
+        }
+        else if(value.type() == QVariant::Double)
+        {
+            defaults[cnt] = remote_config::ConfigKeyValueVariant{it.key().toUtf8().constData(),
+                                                                 value.toDouble()};
+        }
+
+        else if(value.type() == QVariant::String)
+        {
+            //Strings cause crash on extracting from fetch
+            //So workaround in by using data set type
+
+            /*defaults[cnt] = remote_config::ConfigKeyValueVariant{it.key().toLatin1().constData(),
+                                                                 value.toString().toLatin1().constData()};*/
+
+            QByteArray data = value.toString().toUtf8();
+            defaults[cnt] = remote_config::ConfigKeyValueVariant{
+                                it.key().toUtf8().constData(),
+                                firebase::Variant::FromMutableBlob(data.constData(), data.size())};
+        }
+        cnt++;
+    }
+    remote_config::SetDefaults(defaults.get(), _parameters.size());
+
+    //Cause crash
+    /*remote_config::SetConfigSetting(remote_config::kConfigSettingDeveloperMode, "1");
+    if ((*remote_config::GetConfigSetting(remote_config::kConfigSettingDeveloperMode)
+                .c_str()) != '1') {
+        qDebug()<<"Failed to enable developer mode";
+    }*/
+
+    qDebug() << self << "::requestConfig" << "start fetching...";
+    auto future = remote_config::Fetch(cacheExpirationInSeconds);
+    qFirebase->addFuture(__QTFIREBASE_ID + ".config.fetch",future);
+}

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -1,0 +1,131 @@
+#ifndef QTFIREBASEREMOTECONFIG_H
+#define QTFIREBASEREMOTECONFIG_H
+
+#include <QObject>
+
+#ifdef QTFIREBASE_BUILD_REMOTE_CONFIG
+
+#include "src/qtfirebase.h"
+
+#if defined(qFirebaseRemoteConfig)
+#undef qFirebaseRemoteConfig
+#endif
+#define qFirebaseRemoteConfig (static_cast<QtFirebaseRemoteConfig *>(QtFirebaseRemoteConfig::instance()))
+
+#include "firebase/remote_config.h"
+/*How to use in QML example
+ * 1. First add parameters in remote config in google firebase console
+
+  RemoteConfig{
+        id: remoteConfig
+        onReadyChanged: {
+            console.log("RemoteConfig ready changed:"+ready);
+            if(ready)
+            {
+                //2. Init remote config with parameters you want to retrieve and default values
+                //default value returned if fetch config from server failed
+                remoteConfig.addParameter("TestLong", 0);
+                remoteConfig.addParameter("TestBool", false);
+                remoteConfig.addParameter("TestDouble", 3.14);
+                remoteConfig.addParameter("TestString","xxx");
+                //3. Initiate fetch (in this example set cache expiration time to 1 second)
+                //Be aware of set low cache expiration time since it will cause too much
+                //requests to server, and it may cause you will be blocked for some time.
+                //This called server throttling, server just refuse your requests for some time and
+                //then begin accept connections again
+                //Default time cache expiration is 12 hours
+
+                remoteConfig.requestConfig(1);
+            }
+        }
+        onLoadedChanged:{
+            console.log("RemoteConfig loaded changed:"+loaded);
+            if(loaded)
+            {
+
+                //4. Retrieve data if loading success
+                console.log("RemoteConfig TestLong:" + remoteConfig.getParameterValue("TestLong"));
+                console.log("RemoteConfig TestBool:" + remoteConfig.getParameterValue("TestBool"));
+                console.log("RemoteConfig TestDouble:" + remoteConfig.getParameterValue("TestDouble"));
+                console.log("RemoteConfig TestString:" + remoteConfig.getParameterValue("TestString"));
+            }
+        }
+        onError:{
+            //5. Handle errors
+            console.log("RemoteConfig error:" + message);
+        }
+    }
+ */
+
+class QtFirebaseRemoteConfig : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
+    Q_PROPERTY(bool loaded READ loaded NOTIFY loadedChanged)
+public:
+    explicit QtFirebaseRemoteConfig(QObject *parent = 0);
+
+    enum Error
+    {
+        kFetchFailureReasonInvalid = firebase::remote_config::kFetchFailureReasonInvalid,
+        kFetchFailureReasonThrottled = firebase::remote_config::kFetchFailureReasonThrottled,
+        kFetchFailureReasonError = firebase::remote_config::kFetchFailureReasonError,
+
+    };
+    Q_ENUM(Error)
+
+
+    QtFirebaseRemoteConfig *instance() {
+            if(self == 0) {
+                self = new QtFirebaseRemoteConfig(0);
+                qDebug() << self << "::instance" << "singleton";
+            }
+            return self;
+        }
+    bool checkInstance(const char *function);
+
+    bool ready();
+    void setReady(bool ready);
+
+    bool loaded();
+    void setLoaded(bool loaded);
+
+public slots:
+    void addParameter(const QString &name, long long defaultValue);
+    void addParameter(const QString &name, double defaultValue);
+    void addParameter(const QString &name, const QString& defaultValue);
+    void addParameter(const QString &name, bool defaultValue);
+
+    QVariant getParameterValue(const QString &name) const;
+    void requestConfig(long long cacheExpirationInSeconds = firebase::remote_config::kDefaultCacheExpiration);
+
+signals:
+    void readyChanged();
+    void loadedChanged();
+    void error(Error code, QString message);
+
+private slots:
+    void addParameterInternal(const QString &name, const QVariant &defaultValue);
+    void init();
+    void onFutureEvent(QString eventId, firebase::FutureBase future);
+private:
+    static QtFirebaseRemoteConfig *self;
+    Q_DISABLE_COPY(QtFirebaseRemoteConfig)
+
+    QString __QTFIREBASE_ID;
+
+    bool _ready;
+    bool _initializing;
+    bool _loaded;
+    typedef QMap<QString, QVariant> ParametersMap;
+    ParametersMap _parameters;
+
+    QString _appId;
+    QByteArray __appIdByteArray;
+    const char *__appId;
+
+};
+
+#endif //QTFIREBASE_BUILD_REMOTE_CONFIG
+
+#endif // QTFIREBASEREMOTECONFIG_H


### PR DESCRIPTION
Implement basic support for Firebase Remote Config 
(not tested for ios, unfortunately I have no environment to test, so linking stage may fail, probably may require project file libs section to fix). 
Example of how to use in QML code added to remote config class header file.