### PR TITLE
Update remote config wrapper API to fit QML code better

### DIFF
--- a/fake/src/qtfirebaseremoteconfig.h
+++ b/fake/src/qtfirebaseremoteconfig.h
@@ -6,7 +6,7 @@
 #ifdef QTFIREBASE_BUILD_REMOTE_CONFIG
 
 #include "src/qtfirebase.h"
-#include <QDebug>
+#include <QVariantMap>
 
 #if defined(qFirebaseRemoteConfig)
 #undef qFirebaseRemoteConfig
@@ -17,7 +17,8 @@ class QtFirebaseRemoteConfig : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
-    Q_PROPERTY(bool loaded READ loaded NOTIFY loadedChanged)
+    Q_PROPERTY(QVariantMap parameters READ parameters WRITE setParameters NOTIFY parametersChanged)
+    Q_PROPERTY(long long cacheExpirationTime READ cacheExpirationTime WRITE setCacheExpirationTime NOTIFY cacheExpirationTimeChanged)
 public:
     enum Error
     {
@@ -27,33 +28,36 @@ public:
     };
     Q_ENUM(Error)
 
-    explicit QtFirebaseRemoteConfig(QObject *parent = 0){Q_UNUSED(parent)}
+    explicit QtFirebaseRemoteConfig(QObject *parent = 0){}
     ~QtFirebaseRemoteConfig() {}
     QtFirebaseRemoteConfig *instance() {
             if(self == 0) {
                 self = new QtFirebaseRemoteConfig(0);
-                qDebug() << self << "::instance" << "singleton";
             }
             return self;
         }
     bool checkInstance(const char *function);
 
     bool ready(){return false;}
-    void setReady(bool ready){Q_UNUSED(ready)}
 
-    bool loaded(){return false;}
-    void setLoaded(bool loaded){Q_UNUSED(loaded)}
+    QVariantMap parameters() const{return QVariantMap();}
+    void setParameters(const QVariantMap& map){Q_UNUSED(map);}
 
+    long long cacheExpirationTime() const{return 0;}
+    void setCacheExpirationTime(long long timeMs){Q_UNUSED(timeMs);}
+public slots:
     void addParameter(const QString &name, long long defaultValue){Q_UNUSED(name); Q_UNUSED(defaultValue);}
     void addParameter(const QString &name, double defaultValue){Q_UNUSED(name); Q_UNUSED(defaultValue);}
     void addParameter(const QString &name, const QString& defaultValue){Q_UNUSED(name); Q_UNUSED(defaultValue);}
     void addParameter(const QString &name, bool defaultValue){Q_UNUSED(name); Q_UNUSED(defaultValue);}
-    QVariant getParameterValue(const QString &name) const {Q_UNUSED(name);return QVariant();}
-    void requestConfig(long long cacheExpirationInSeconds = 0){Q_UNUSED(cacheExpirationInSeconds);}
+    QVariant getParameterValue(const QString &name) const{return QString();}
+    void fetch(){}
+    void fetchNow(){}
 signals:
     void readyChanged();
-    void loadedChanged();
     void error(Error code, QString message);
+    void parametersChanged();
+    void cacheExpirationTimeChanged();
 
 private:
     static QtFirebaseRemoteConfig *self;

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -14,11 +14,63 @@
 
 #include "firebase/remote_config.h"
 
+/*Feature information available at https://firebase.google.com/docs/remote-config/
+
+  How to use in QML example
+  0. Add parameters in remote config section at google firebase web console (https://console.firebase.google.com)
+
+  RemoteConfig{
+        id: remoteConfig
+
+        //1. Initialize parameters you would like to fetch from server and their default values
+        parameters: {
+            "TestString" : "test",
+            "TestDouble" : 2.56,
+            "TestLong" : 1100,
+            "TestBool" : true
+        }
+
+        //2. Set cache expiration time in milliseconds, see step 3 for details about cache
+        cacheExpirationTime: 12*3600*1000 //12 hours in milliseconds (suggested as default in firebase)
+
+        //3. When remote config properly initialized request data from server
+        onReadyChanged: {
+            console.log("RemoteConfig ready changed:"+ready);
+            if(ready)
+            {
+                remoteConfig.fetch();
+                //If the data in the cache was fetched no longer than cacheExpirationTime ago,
+                //this method will return the cached data. If not, a fetch from the
+                //Remote Config Server will be attempted.
+                //If you need to get data urgent use fetchNow(), it is equal to fetch() call with cacheExpirationTime=0
+                //Be careful with urgent requests, too often requests will result to server throthling
+                //which means it will refuse connections for some time
+            }
+        }
+
+        //4. If data was retrieved (both from server or cache) the handler will be called
+        //you can access data by accessing the "parameters" member variable
+
+        onParametersChanged:{
+            console.log("RemoteConfig TestString:" + parameters['TestString']);
+            console.log("RemoteConfig TestDouble:" + parameters['TestDouble']);
+            console.log("RemoteConfig TestLong:" + parameters['TestLong']);
+            console.log("RemoteConfig TestBool:" + parameters['TestBool']);
+        }
+
+        //5. Handle errors
+        onError:{
+            console.log("RemoteConfig error code:" + code + " message:" + message);
+        }
+    }
+ */
+
 class QtFirebaseRemoteConfig : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
-    Q_PROPERTY(bool loaded READ loaded NOTIFY loadedChanged)
+    Q_PROPERTY(QVariantMap parameters READ parameters WRITE setParameters NOTIFY parametersChanged)
+    Q_PROPERTY(long long cacheExpirationTime READ cacheExpirationTime WRITE setCacheExpirationTime NOTIFY cacheExpirationTimeChanged)
 public:
     explicit QtFirebaseRemoteConfig(QObject *parent = 0);
 
@@ -27,44 +79,55 @@ public:
         kFetchFailureReasonInvalid = firebase::remote_config::kFetchFailureReasonInvalid,
         kFetchFailureReasonThrottled = firebase::remote_config::kFetchFailureReasonThrottled,
         kFetchFailureReasonError = firebase::remote_config::kFetchFailureReasonError,
-
     };
     Q_ENUM(Error)
 
     QtFirebaseRemoteConfig *instance() {
-            if(self == 0) {
-                self = new QtFirebaseRemoteConfig(0);
-                qDebug() << self << "::instance" << "singleton";
-            }
-            return self;
+        if(self == 0) {
+            self = new QtFirebaseRemoteConfig(0);
+            qDebug() << self << "::instance" << "singleton";
         }
+        return self;
+    }
+
     bool checkInstance(const char *function);
-
     bool ready();
-    void setReady(bool ready);
 
-    bool loaded();
-    void setLoaded(bool loaded);
+    QVariantMap parameters() const;
+    void setParameters(const QVariantMap& map);
 
+    long long cacheExpirationTime() const;
+    void setCacheExpirationTime(long long timeMs);
 public slots:
     void addParameter(const QString &name, long long defaultValue);
     void addParameter(const QString &name, double defaultValue);
     void addParameter(const QString &name, const QString& defaultValue);
     void addParameter(const QString &name, bool defaultValue);
-
     QVariant getParameterValue(const QString &name) const;
-    void requestConfig(long long cacheExpirationInSeconds = firebase::remote_config::kDefaultCacheExpiration);
 
+    //If the data in the cache was fetched no longer than cacheExpirationTime ago,
+    //this method will return the cached data. If not, a fetch from the
+    //Remote Config Server will be attempted.
+    //cacheExpirationTime in QtFirebase should be set in milliseconds
+    //See for details
+    //https://firebase.google.com/docs/reference/android/com/google/firebase/remoteconfig/FirebaseRemoteConfig#fetch()
+    void fetch();
+    void fetchNow();//calls fetch with cacheExpirationTime = 0
 signals:
     void readyChanged();
-    void loadedChanged();
     void error(Error code, QString message);
+    void parametersChanged();
+    void cacheExpirationTimeChanged();
 
 private slots:
     void addParameterInternal(const QString &name, const QVariant &defaultValue);
     void init();
     void onFutureEvent(QString eventId, firebase::FutureBase future);
+
 private:
+    void setReady(bool ready);
+    void fetch(long long cacheExpirationInSeconds);
+
     static QtFirebaseRemoteConfig *self;
     Q_DISABLE_COPY(QtFirebaseRemoteConfig)
 
@@ -72,9 +135,8 @@ private:
 
     bool _ready;
     bool _initializing;
-    bool _loaded;
-    typedef QMap<QString, QVariant> ParametersMap;
-    ParametersMap _parameters;
+    QVariantMap _parameters;
+    long long _cacheExpirationTime;
 
     QString _appId;
     QByteArray __appIdByteArray;


### PR DESCRIPTION
Update RemoteConfig class to fit QML better. Added "parameters" and "cacheExpirationTime" variable in milliseconds. Removed "loaded" variables and signals. Updated example code in the class header.