### PR TITLE
Fix singletons in fake mode.

### DIFF
--- a/fake/src/qtfirebase.cpp
+++ b/fake/src/qtfirebase.cpp
@@ -1,0 +1,15 @@
+#include "qtfirebaseanalytics.h"
+#include "qtfirebaseremoteconfig.h"
+#include "qtfirebaseadmob.h"
+
+#ifdef QTFIREBASE_BUILD_ANALYTICS
+QtFirebaseAnalytics* QtFirebaseAnalytics::self = nullptr;
+#endif
+
+#ifdef QTFIREBASE_BUILD_REMOTE_CONFIG
+QtFirebaseRemoteConfig* QtFirebaseRemoteConfig::self = nullptr;
+#endif
+
+#ifdef QTFIREBASE_BUILD_ADMOB
+QtFirebaseAdMob *QtFirebaseAdMob::self = nullptr;
+#endif

--- a/fake/src/qtfirebaseremoteconfig.h
+++ b/fake/src/qtfirebaseremoteconfig.h
@@ -63,7 +63,7 @@ private:
     static QtFirebaseRemoteConfig *self;
     Q_DISABLE_COPY(QtFirebaseRemoteConfig)
 };
-
 #endif //QTFIREBASE_BUILD_REMOTE_CONFIG
 
 #endif // QTFIREBASEREMOTECONFIG_H
+

--- a/fake/src/qtfirebaseremoteconfig.h
+++ b/fake/src/qtfirebaseremoteconfig.h
@@ -30,7 +30,7 @@ public:
 
     explicit QtFirebaseRemoteConfig(QObject *parent = 0){}
     ~QtFirebaseRemoteConfig() {}
-    QtFirebaseRemoteConfig *instance() {
+    static QtFirebaseRemoteConfig *instance() {
             if(self == 0) {
                 self = new QtFirebaseRemoteConfig(0);
             }

--- a/qtfirebase_dummy.pri
+++ b/qtfirebase_dummy.pri
@@ -31,3 +31,6 @@ contains(DEFINES,QTFIREBASE_BUILD_REMOTE_CONFIG) {
     HEADERS += $$QTFIREBASE_FAKE_PATH/src/qtfirebaseremoteconfig.h
 }
 
+SOURCES += \
+    $$PWD/fake/src/qtfirebase.cpp
+

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -1,4 +1,4 @@
-#include "qtfirebaseremoteconfig.h"
+QtFirebaseAnalytics *QtFirebaseAnalytics::self = 0;#include "qtfirebaseremoteconfig.h"
 #include <memory>
 namespace remote_config = ::firebase::remote_config;
 

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -82,7 +82,7 @@ public:
     };
     Q_ENUM(Error)
 
-    QtFirebaseRemoteConfig *instance() {
+    static QtFirebaseRemoteConfig *instance() {
         if(self == 0) {
             self = new QtFirebaseRemoteConfig(0);
             qDebug() << self << "::instance" << "singleton";


### PR DESCRIPTION
- QtFirebaseRemoteConfig::self should be static
- add src/fake/qtfirebase.cpp to initilize ::self of each class.