### PR TITLE
Add support to admob::NativeExpress type; fix some compilation warnings 

### DIFF
--- a/fake/src/qtfirebaseadmob.h
+++ b/fake/src/qtfirebaseadmob.h
@@ -212,6 +212,82 @@ public slots:
 
 
 /*
+ * AdMobNativeExpressAd
+ */
+class AdMobNativeExpressAd : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
+    Q_PROPERTY(bool loaded READ loaded NOTIFY loadedChanged)
+
+    Q_PROPERTY(QString adUnitId READ adUnitId WRITE setAdUnitId NOTIFY adUnitIdChanged)
+
+    Q_PROPERTY(bool visible READ visible WRITE setVisible NOTIFY visibleChanged)
+
+    Q_PROPERTY(int x READ getX WRITE setX NOTIFY xChanged)
+    Q_PROPERTY(int y READ getY WRITE setY NOTIFY yChanged)
+    Q_PROPERTY(int width READ getWidth WRITE setWidth NOTIFY widthChanged)
+    Q_PROPERTY(int height READ getHeight WRITE setHeight NOTIFY heightChanged)
+
+    Q_PROPERTY(QtFirebaseAdMobRequest* request READ request WRITE setRequest NOTIFY requestChanged)
+
+public:
+    AdMobNativeExpressAd(QObject* parent = 0) { Q_UNUSED(parent); }
+    ~AdMobNativeExpressAd() {}
+
+    bool ready() { return false; }
+    void setReady(bool ready) { Q_UNUSED(ready); }
+
+    bool loaded() { return false; }
+    void setLoaded(bool loaded) { Q_UNUSED(loaded); }
+
+    QString adUnitId() { return ""; }
+    void setAdUnitId(const QString &adUnitId) { Q_UNUSED(adUnitId); }
+
+    bool visible() { return false; }
+    void setVisible(bool visible) { Q_UNUSED(visible); }
+
+    int getX() { return 0; }
+    void setX(const int &x) { Q_UNUSED(x); }
+
+    int getY() { return 0; }
+    void setY(const int &y) { Q_UNUSED(y); }
+
+    int getWidth() {return 0; }
+    void setWidth(const int &width) { Q_UNUSED(width); }
+
+    int getHeight() { return 0; }
+    void setHeight(const int &height) { Q_UNUSED(height); }
+
+    QtFirebaseAdMobRequest* request()  { return 0; }
+    void setRequest(QtFirebaseAdMobRequest *request) { Q_UNUSED(request); }
+
+signals:
+    void readyChanged();
+    void loadedChanged();
+    void adUnitIdChanged();
+
+    void visibleChanged();
+    void xChanged();
+    void yChanged();
+    void widthChanged();
+    void heightChanged();
+    void requestChanged();
+
+    void loading();
+
+    void error(int errorCode);
+
+public slots:
+    void load() {}
+    void show() {}
+    void hide() {}
+    void moveTo(int x, int y) { Q_UNUSED(x); Q_UNUSED(y); }
+
+};
+
+/*
  * AdMobInterstitial
  */
 class QtFirebaseAdMobInterstitial : public QObject

--- a/fake/src/qtfirebaseremoteconfig.h
+++ b/fake/src/qtfirebaseremoteconfig.h
@@ -28,7 +28,7 @@ public:
     };
     Q_ENUM(Error)
 
-    explicit QtFirebaseRemoteConfig(QObject *parent = 0){}
+    explicit QtFirebaseRemoteConfig(QObject *parent = 0){ Q_UNUSED(parent); }
     ~QtFirebaseRemoteConfig() {}
     static QtFirebaseRemoteConfig *instance() {
             if(self == 0) {
@@ -50,7 +50,7 @@ public slots:
     void addParameter(const QString &name, double defaultValue){Q_UNUSED(name); Q_UNUSED(defaultValue);}
     void addParameter(const QString &name, const QString& defaultValue){Q_UNUSED(name); Q_UNUSED(defaultValue);}
     void addParameter(const QString &name, bool defaultValue){Q_UNUSED(name); Q_UNUSED(defaultValue);}
-    QVariant getParameterValue(const QString &name) const{return QString();}
+    QVariant getParameterValue(const QString/* &name*/) const{return QString();}
     void fetch(){}
     void fetchNow(){}
 signals:

--- a/src/qtfirebaseadmob.cpp
+++ b/src/qtfirebaseadmob.cpp
@@ -731,7 +731,7 @@ void QtFirebaseAdMobBanner::init()
     if(!_ready && !_initializing) {
         _initializing = true;
 
-        _banner = new admob::NativeExpressAdView();
+        _banner = new admob::BannerView();
 
         admob::AdSize ad_size;
         ad_size.ad_size_type = admob::kAdSizeStandard;
@@ -925,8 +925,8 @@ QtFirebaseAdMobNativeAd::QtFirebaseAdMobNativeAd(QObject *parent) : QObject(pare
 QtFirebaseAdMobNativeAd::~QtFirebaseAdMobNativeAd()
 {
     if(_ready) {
-        _banner->Destroy();
-        qFirebase->waitForFutureCompletion(_banner->DestroyLastResult()); // TODO MAYBE move or duplicate to QtFirebaseAdMob with admob::kAdMobError* checking? (Will save ALOT of cycles on errors)
+        _nativeAd->Destroy();
+        qFirebase->waitForFutureCompletion(_nativeAd->DestroyLastResult()); // TODO MAYBE move or duplicate to QtFirebaseAdMob with admob::kAdMobError* checking? (Will save ALOT of cycles on errors)
         qDebug() << this << "::~QtFirebaseAdMobBanner" << "Destroyed banner";
     }
 }
@@ -992,7 +992,7 @@ void QtFirebaseAdMobNativeAd::setVisible(bool visible)
 
     if(_visible != visible) {
         if(visible) {
-            firebase::FutureBase future = _banner->Show();
+            firebase::FutureBase future = _nativeAd->Show();
             qFirebase->waitForFutureCompletion(future); // TODO move or duplicate to QtFirebaseAdMob with admob::kAdMobError* checking? (Will save ALOT of cycles on errors)
             if(future.error() != admob::kAdMobErrorNone) {
                 qDebug() << this << "::setVisible" << visible <<  "ERROR code" << future.error() << "message" << future.error_message();
@@ -1000,7 +1000,7 @@ void QtFirebaseAdMobNativeAd::setVisible(bool visible)
             }
             qDebug() << this << "::setVisible native showed";
         } else {
-            firebase::FutureBase future = _banner->Hide();
+            firebase::FutureBase future = _nativeAd->Hide();
             qFirebase->waitForFutureCompletion(future); // TODO move or duplicate to QtFirebaseAdMob with admob::kAdMobError* checking? (Will save ALOT of cycles on errors)
             if(future.error() != admob::kAdMobErrorNone) {
                 qDebug() << this << "::setVisible" << visible << "ERROR code" << future.error() << "message" << future.error_message();
@@ -1032,7 +1032,7 @@ void QtFirebaseAdMobNativeAd::setX(const int &x)
 
     if(_x != x) {
         qDebug() << this << "::setX moving to" << x << "," << _y;
-        _banner->MoveTo(x, _y); // NOTE Potential dangerous code? The code below is more safe but will hang until the "I give up limit" is reached on some devices :/
+        _nativeAd->MoveTo(x, _y); // NOTE Potential dangerous code? The code below is more safe but will hang until the "I give up limit" is reached on some devices :/
         // This can mybe be fixed by using the Listeners for the bounding rect??
         /*
         firebase::FutureBase future = _banner->MoveTo(x, _y);
@@ -1066,7 +1066,7 @@ void QtFirebaseAdMobNativeAd::setY(const int &y)
 
     if(_y != y) {
         qDebug() << this << "::setY moving to" << _x << "," << y;
-        _banner->MoveTo(_x, y); // NOTE Potential dangerous code? The code below is more safe but will hang until the "I give up limit" is reached on some devices :/
+        _nativeAd->MoveTo(_x, y); // NOTE Potential dangerous code? The code below is more safe but will hang until the "I give up limit" is reached on some devices :/
         /*
         firebase::FutureBase future = _banner->MoveTo(_x, y);
         qFirebase->waitForFutureCompletion(future); // TODO move or duplicate to QtFirebaseAdMob with admob::kAdMobError* checking? (Will save ALOT of cycles on errors)
@@ -1157,7 +1157,7 @@ void QtFirebaseAdMobNativeAd::init()
     if(!_ready && !_initializing) {
         _initializing = true;
 
-        _banner = new admob::NativeExpressAdView();
+        _nativeAd = new admob::NativeExpressAdView();
 
         admob::AdSize ad_size;
         ad_size.ad_size_type = admob::kAdSizeStandard;
@@ -1167,7 +1167,7 @@ void QtFirebaseAdMobNativeAd::init()
         // A reference to an iOS UIView or an Android Activity.
         // This is the parent UIView or Activity of the banner view.
         qDebug() << this << "::init initializing with AdUnitID" << __adUnitIdByteArray.constData();
-        firebase::FutureBase future = _banner->Initialize(static_cast<admob::AdParent>(_nativeUIElement), __adUnitIdByteArray.constData(), ad_size);
+        firebase::FutureBase future = _nativeAd->Initialize(static_cast<admob::AdParent>(_nativeUIElement), __adUnitIdByteArray.constData(), ad_size);
         qDebug() << this << "::init" << "native initialized";
         qFirebase->addFuture(__QTFIREBASE_ID + ".nativead.init",future);
 
@@ -1239,7 +1239,7 @@ void QtFirebaseAdMobNativeAd::load()
     qDebug() << this << "::load() getting request data";
     emit loading();
     admob::AdRequest request = _request->asAdMobRequest();
-    firebase::FutureBase future = _banner->LoadAd(request);
+    firebase::FutureBase future = _nativeAd->LoadAd(request);
     qFirebase->addFuture(__QTFIREBASE_ID + ".nativead.loaded",future);
 }
 
@@ -1258,7 +1258,7 @@ void QtFirebaseAdMobNativeAd::moveTo(int x, int y)
 {
     if(_ready) {
         qDebug() << this << "::moveTo moving to" << x << "," << y;
-        _banner->MoveTo(x, y); // NOTE Potential dangerous code? The code below is more safe but will hang until the "I give up limit" is reached on some devices :/
+        _nativeAd->MoveTo(x, y); // NOTE Potential dangerous code? The code below is more safe but will hang until the "I give up limit" is reached on some devices :/
         /*
         firebase::FutureBase future = _banner->MoveTo(x, y);
         qFirebase->waitForFutureCompletion(future); // TODO move or duplicate to QtFirebaseAdMob with admob::kAdMobError* checking? (Will save ALOT of cycles on errors)
@@ -1292,22 +1292,22 @@ void QtFirebaseAdMobNativeAd::moveTo(int position)
     // The code below is more safe but will hang until the "I give up limit" is reached on some devices if using a waitforfuture... strategy :/
     if(position == PositionTopCenter) {
         qDebug() << this << "::moveTo position top-center";
-        _banner->MoveTo(admob::NativeExpressAdView::kPositionTop);
+        _nativeAd->MoveTo(admob::NativeExpressAdView::kPositionTop);
     } else if(position == PositionTopLeft) {
         qDebug() << this << "::moveTo position top-left";
-        _banner->MoveTo(admob::NativeExpressAdView::kPositionTopLeft);
+        _nativeAd->MoveTo(admob::NativeExpressAdView::kPositionTopLeft);
     } else if(position == PositionTopRight) {
         qDebug() << this << "::moveTo position top-right";
-        _banner->MoveTo(admob::NativeExpressAdView::kPositionTopRight);
+        _nativeAd->MoveTo(admob::NativeExpressAdView::kPositionTopRight);
     } else if(position == PositionBottomCenter) {
         qDebug() << this << "::moveTo position bottom-center";
-        _banner->MoveTo(admob::NativeExpressAdView::kPositionBottom);
+        _nativeAd->MoveTo(admob::NativeExpressAdView::kPositionBottom);
     } else if(position == PositionBottomLeft) {
         qDebug() << this << "::moveTo position bottom-left";
-        _banner->MoveTo(admob::NativeExpressAdView::kPositionBottomLeft);
+        _nativeAd->MoveTo(admob::NativeExpressAdView::kPositionBottomLeft);
     } else if(position == PositionBottomRight) {
         qDebug() << this << "::moveTo position bottom-right";
-        _banner->MoveTo(admob::NativeExpressAdView::kPositionBottomRight);
+        _nativeAd->MoveTo(admob::NativeExpressAdView::kPositionBottomRight);
     } else {
         qDebug() << this << "::moveTo position unknown" << position;
     }

--- a/src/qtfirebaseadmob.cpp
+++ b/src/qtfirebaseadmob.cpp
@@ -890,10 +890,10 @@ void QtFirebaseAdMobBanner::moveTo(int position)
 
 
 /*
- * AdMobBanner
+ * AdMobNativeExpressAd
  *
  */
-QtFirebaseAdMobNativeAd::QtFirebaseAdMobNativeAd(QObject *parent) : QObject(parent)
+QtFirebaseAdMobNativeExpressAd::QtFirebaseAdMobNativeExpressAd(QObject *parent) : QObject(parent)
 {
     __QTFIREBASE_ID = QString().sprintf("%8p", this);
     _ready = false;
@@ -913,30 +913,30 @@ QtFirebaseAdMobNativeAd::QtFirebaseAdMobNativeAd(QObject *parent) : QObject(pare
     //connect(this,&QtFirebaseAdMobNativeAd::visibleChanged, this, &QtFirebaseAdMobNativeAd::onVisibleChanged);
 
     _initTimer = new QTimer(this);
-    connect(_initTimer, &QTimer::timeout, this, &QtFirebaseAdMobNativeAd::init);
+    connect(_initTimer, &QTimer::timeout, this, &QtFirebaseAdMobNativeExpressAd::init);
     _initTimer->start(500);
 
-    connect(qFirebase,&QtFirebase::futureEvent, this, &QtFirebaseAdMobNativeAd::onFutureEvent);
+    connect(qFirebase,&QtFirebase::futureEvent, this, &QtFirebaseAdMobNativeExpressAd::onFutureEvent);
 
-    connect(qGuiApp,&QGuiApplication::applicationStateChanged, this, &QtFirebaseAdMobNativeAd::onApplicationStateChanged);
+    connect(qGuiApp,&QGuiApplication::applicationStateChanged, this, &QtFirebaseAdMobNativeExpressAd::onApplicationStateChanged);
 
 }
 
-QtFirebaseAdMobNativeAd::~QtFirebaseAdMobNativeAd()
+QtFirebaseAdMobNativeExpressAd::~QtFirebaseAdMobNativeExpressAd()
 {
     if(_ready) {
         _nativeAd->Destroy();
         qFirebase->waitForFutureCompletion(_nativeAd->DestroyLastResult()); // TODO MAYBE move or duplicate to QtFirebaseAdMob with admob::kAdMobError* checking? (Will save ALOT of cycles on errors)
-        qDebug() << this << "::~QtFirebaseAdMobBanner" << "Destroyed banner";
+        qDebug() << this << "::~QtFirebaseAdMobNativeExpressAd" << "Destroyed";
     }
 }
 
-bool QtFirebaseAdMobNativeAd::ready()
+bool QtFirebaseAdMobNativeExpressAd::ready()
 {
     return _ready;
 }
 
-void QtFirebaseAdMobNativeAd::setReady(bool ready)
+void QtFirebaseAdMobNativeExpressAd::setReady(bool ready)
 {
     if (_ready != ready) {
         _ready = ready;
@@ -944,12 +944,12 @@ void QtFirebaseAdMobNativeAd::setReady(bool ready)
     }
 }
 
-bool QtFirebaseAdMobNativeAd::loaded()
+bool QtFirebaseAdMobNativeExpressAd::loaded()
 {
     return _loaded;
 }
 
-void QtFirebaseAdMobNativeAd::setLoaded(bool loaded)
+void QtFirebaseAdMobNativeExpressAd::setLoaded(bool loaded)
 {
     if(_loaded != loaded) {
         _loaded = loaded;
@@ -958,12 +958,12 @@ void QtFirebaseAdMobNativeAd::setLoaded(bool loaded)
     }
 }
 
-QString QtFirebaseAdMobNativeAd::adUnitId()
+QString QtFirebaseAdMobNativeExpressAd::adUnitId()
 {
     return _adUnitId;
 }
 
-void QtFirebaseAdMobNativeAd::setAdUnitId(const QString &adUnitId)
+void QtFirebaseAdMobNativeExpressAd::setAdUnitId(const QString &adUnitId)
 {
     if(_adUnitId != adUnitId) {
         _adUnitId = adUnitId;
@@ -973,12 +973,12 @@ void QtFirebaseAdMobNativeAd::setAdUnitId(const QString &adUnitId)
     }
 }
 
-bool QtFirebaseAdMobNativeAd::visible()
+bool QtFirebaseAdMobNativeExpressAd::visible()
 {
     return _visible;
 }
 
-void QtFirebaseAdMobNativeAd::setVisible(bool visible)
+void QtFirebaseAdMobNativeExpressAd::setVisible(bool visible)
 {
     if(!_ready) {
         qDebug() << this << "::setVisible native part not ready";
@@ -998,7 +998,7 @@ void QtFirebaseAdMobNativeAd::setVisible(bool visible)
                 qDebug() << this << "::setVisible" << visible <<  "ERROR code" << future.error() << "message" << future.error_message();
                 return;
             }
-            qDebug() << this << "::setVisible native showed";
+            qDebug() << this << "::setVisible native express ad showed";
         } else {
             firebase::FutureBase future = _nativeAd->Hide();
             qFirebase->waitForFutureCompletion(future); // TODO move or duplicate to QtFirebaseAdMob with admob::kAdMobError* checking? (Will save ALOT of cycles on errors)
@@ -1006,19 +1006,19 @@ void QtFirebaseAdMobNativeAd::setVisible(bool visible)
                 qDebug() << this << "::setVisible" << visible << "ERROR code" << future.error() << "message" << future.error_message();
                 return;
             }
-            qDebug() << this << "::setVisible native hidden";
+            qDebug() << this << "::setVisible native express ad hidden";
         }
         _visible = visible;
         emit visibleChanged();
     }
 }
 
-int QtFirebaseAdMobNativeAd::getX()
+int QtFirebaseAdMobNativeExpressAd::getX()
 {
     return _x;
 }
 
-void QtFirebaseAdMobNativeAd::setX(const int &x)
+void QtFirebaseAdMobNativeExpressAd::setX(const int &x)
 {
     if(!_ready) {
         qDebug() << this << "::setX native part not ready - so not moving";
@@ -1047,12 +1047,12 @@ void QtFirebaseAdMobNativeAd::setX(const int &x)
     }
 }
 
-int QtFirebaseAdMobNativeAd::getY()
+int QtFirebaseAdMobNativeExpressAd::getY()
 {
     return _y;
 }
 
-void QtFirebaseAdMobNativeAd::setY(const int &y)
+void QtFirebaseAdMobNativeExpressAd::setY(const int &y)
 {
     if(!_ready) {
         qDebug() << this << "::setY native part not ready - so not moving";
@@ -1081,12 +1081,12 @@ void QtFirebaseAdMobNativeAd::setY(const int &y)
     }
 }
 
-int QtFirebaseAdMobNativeAd::getWidth()
+int QtFirebaseAdMobNativeExpressAd::getWidth()
 {
     return _width;
 }
 
-void QtFirebaseAdMobNativeAd::setWidth(const int &width)
+void QtFirebaseAdMobNativeExpressAd::setWidth(const int &width)
 {
     if(_width != width) {
         _width = width;
@@ -1094,12 +1094,12 @@ void QtFirebaseAdMobNativeAd::setWidth(const int &width)
     }
 }
 
-int QtFirebaseAdMobNativeAd::getHeight()
+int QtFirebaseAdMobNativeExpressAd::getHeight()
 {
     return _height;
 }
 
-void QtFirebaseAdMobNativeAd::setHeight(const int &height)
+void QtFirebaseAdMobNativeExpressAd::setHeight(const int &height)
 {
     if(_height != height) {
         _height = height;
@@ -1107,12 +1107,12 @@ void QtFirebaseAdMobNativeAd::setHeight(const int &height)
     }
 }
 
-QtFirebaseAdMobRequest* QtFirebaseAdMobNativeAd::request() const
+QtFirebaseAdMobRequest* QtFirebaseAdMobNativeExpressAd::request() const
 {
     return _request;
 }
 
-void QtFirebaseAdMobNativeAd::setRequest(QtFirebaseAdMobRequest* request)
+void QtFirebaseAdMobNativeExpressAd::setRequest(QtFirebaseAdMobRequest* request)
 {
     if(_request != request) {
         _request = request;
@@ -1120,7 +1120,7 @@ void QtFirebaseAdMobNativeAd::setRequest(QtFirebaseAdMobRequest* request)
     }
 }
 
-void QtFirebaseAdMobNativeAd::init()
+void QtFirebaseAdMobNativeExpressAd::init()
 {
     //qDebug() << "QtFirebase.AdMobBanner pre-initialize _ready" << _ready << "_init" << _initializing;
     if(!qFirebase->ready()) {
@@ -1165,21 +1165,21 @@ void QtFirebaseAdMobNativeAd::init()
         ad_size.height = getHeight();
 
         // A reference to an iOS UIView or an Android Activity.
-        // This is the parent UIView or Activity of the banner view.
+        // This is the parent UIView or Activity of the native express ad view.
         qDebug() << this << "::init initializing with AdUnitID" << __adUnitIdByteArray.constData();
         firebase::FutureBase future = _nativeAd->Initialize(static_cast<admob::AdParent>(_nativeUIElement), __adUnitIdByteArray.constData(), ad_size);
         qDebug() << this << "::init" << "native initialized";
-        qFirebase->addFuture(__QTFIREBASE_ID + ".nativead.init",future);
+        qFirebase->addFuture(__QTFIREBASE_ID + ".nativeexpressad.init",future);
 
     }
 }
 
-void QtFirebaseAdMobNativeAd::onFutureEvent(QString eventId, firebase::FutureBase future)
+void QtFirebaseAdMobNativeExpressAd::onFutureEvent(QString eventId, firebase::FutureBase future)
 {
     if(!eventId.startsWith(__QTFIREBASE_ID))
         return;
 
-    if(eventId == __QTFIREBASE_ID+".nativead.init") {
+    if(eventId == __QTFIREBASE_ID+".nativeexpressad.init") {
 
         if (future.error() != admob::kAdMobErrorNone) {
             qDebug() << this << "::onFutureEvent" << "initializing failed." << "ERROR: Action failed with error code and message: " << future.error() << future.error_message();
@@ -1196,7 +1196,7 @@ void QtFirebaseAdMobNativeAd::onFutureEvent(QString eventId, firebase::FutureBas
         setReady(true);
     }
 
-    if(eventId == __QTFIREBASE_ID+".nativead.loaded") {
+    if(eventId == __QTFIREBASE_ID+".nativeexpressad.loaded") {
 
         if (future.error() != admob::kAdMobErrorNone) {
             int errorCode = future.error();
@@ -1211,7 +1211,7 @@ void QtFirebaseAdMobNativeAd::onFutureEvent(QString eventId, firebase::FutureBas
     }
 }
 
-void QtFirebaseAdMobNativeAd::onApplicationStateChanged(Qt::ApplicationState state)
+void QtFirebaseAdMobNativeExpressAd::onApplicationStateChanged(Qt::ApplicationState state)
 {
     // NOTE makes sure the ad banner is on top of the Qt surface
     #if defined(__ANDROID__)
@@ -1224,7 +1224,7 @@ void QtFirebaseAdMobNativeAd::onApplicationStateChanged(Qt::ApplicationState sta
     #endif
 }
 
-void QtFirebaseAdMobNativeAd::load()
+void QtFirebaseAdMobNativeExpressAd::load()
 {
     if(!_ready) {
         qDebug() << this << "::load" << "not ready";
@@ -1240,21 +1240,21 @@ void QtFirebaseAdMobNativeAd::load()
     emit loading();
     admob::AdRequest request = _request->asAdMobRequest();
     firebase::FutureBase future = _nativeAd->LoadAd(request);
-    qFirebase->addFuture(__QTFIREBASE_ID + ".nativead.loaded",future);
+    qFirebase->addFuture(__QTFIREBASE_ID + ".nativeexpressad.loaded",future);
 }
 
 
-void QtFirebaseAdMobNativeAd::show()
+void QtFirebaseAdMobNativeExpressAd::show()
 {
     setVisible(true);
 }
 
-void QtFirebaseAdMobNativeAd::hide()
+void QtFirebaseAdMobNativeExpressAd::hide()
 {
     setVisible(false);
 }
 
-void QtFirebaseAdMobNativeAd::moveTo(int x, int y)
+void QtFirebaseAdMobNativeExpressAd::moveTo(int x, int y)
 {
     if(_ready) {
         qDebug() << this << "::moveTo moving to" << x << "," << y;
@@ -1281,7 +1281,7 @@ void QtFirebaseAdMobNativeAd::moveTo(int x, int y)
     }
 }
 
-void QtFirebaseAdMobNativeAd::moveTo(int position)
+void QtFirebaseAdMobNativeExpressAd::moveTo(int position)
 {
     if(!_ready) {
         qDebug() << this << "::moveTo" << "not ready";

--- a/src/qtfirebaseadmob.h
+++ b/src/qtfirebaseadmob.h
@@ -313,7 +313,7 @@ private:
 /*
  * AdMobNativeExpress
  */
-class QtFirebaseAdMobNativeAd : public QObject
+class QtFirebaseAdMobNativeExpressAd : public QObject
 {
     Q_OBJECT
 
@@ -343,8 +343,8 @@ public:
     };
     Q_ENUM(Position)
 
-    QtFirebaseAdMobNativeAd(QObject* parent = 0);
-    ~QtFirebaseAdMobNativeAd();
+    QtFirebaseAdMobNativeExpressAd(QObject* parent = 0);
+    ~QtFirebaseAdMobNativeExpressAd();
 
     bool ready();
     void setReady(bool ready);

--- a/src/qtfirebaseadmob.h
+++ b/src/qtfirebaseadmob.h
@@ -13,6 +13,7 @@
 #include "firebase/admob.h"
 #include "firebase/admob/types.h"
 #include "firebase/admob/banner_view.h"
+#include "firebase/admob/native_express_ad_view.h"
 #include "firebase/admob/interstitial_ad.h"
 #include "firebase/admob/rewarded_video.h"
 
@@ -225,6 +226,125 @@ public:
 
     QtFirebaseAdMobBanner(QObject* parent = 0);
     ~QtFirebaseAdMobBanner();
+
+    bool ready();
+    void setReady(bool ready);
+
+    bool loaded();
+    void setLoaded(bool loaded);
+
+    QString adUnitId();
+    void setAdUnitId(const QString &adUnitId);
+
+    bool visible();
+    void setVisible(bool visible);
+
+    int getX();
+    void setX(const int &x);
+
+    int getY();
+    void setY(const int &y);
+
+    int getWidth();
+    void setWidth(const int &width);
+
+    int getHeight();
+    void setHeight(const int &height);
+
+    QtFirebaseAdMobRequest* request() const;
+    void setRequest(QtFirebaseAdMobRequest *request);
+
+signals:
+    void readyChanged();
+    void loadedChanged();
+    void adUnitIdChanged();
+
+    void visibleChanged();
+    void xChanged();
+    void yChanged();
+    void widthChanged();
+    void heightChanged();
+    void requestChanged();
+    void loading();
+
+    void error(QtFirebaseAdMob::Error code, QString message);
+
+public slots:
+    void load();
+    void show();
+    void hide();
+    void moveTo(int x, int y);
+    void moveTo(int position);
+
+private slots:
+    void init();
+    void onFutureEvent(QString eventId, firebase::FutureBase future);
+    void onApplicationStateChanged(Qt::ApplicationState state);
+
+private:
+    QString __QTFIREBASE_ID;
+    bool _ready;
+    bool _initializing;
+    bool _loaded;
+
+    bool _isFirstInit;
+
+    bool _visible;
+
+    int _x;
+    int _y;
+    int _width;
+    int _height;
+
+    QtFirebaseAdMobRequest* _request;
+
+    QString _adUnitId;
+    QByteArray __adUnitIdByteArray;
+    //const char *__adUnitId; // TODO use __adUnitIdByteArray.constData() instead ?
+
+    void *_nativeUIElement;
+
+    QTimer *_initTimer;
+
+    firebase::admob::NativeExpressAdView* _banner;
+
+};
+
+/*
+ * AdMobNativeExpress
+ */
+class QtFirebaseAdMobNativeAd : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
+    Q_PROPERTY(bool loaded READ loaded NOTIFY loadedChanged)
+
+    Q_PROPERTY(QString adUnitId READ adUnitId WRITE setAdUnitId NOTIFY adUnitIdChanged)
+
+    Q_PROPERTY(bool visible READ visible WRITE setVisible NOTIFY visibleChanged)
+
+    Q_PROPERTY(int x READ getX WRITE setX NOTIFY xChanged)
+    Q_PROPERTY(int y READ getY WRITE setY NOTIFY yChanged)
+    Q_PROPERTY(int width READ getWidth WRITE setWidth NOTIFY widthChanged)
+    Q_PROPERTY(int height READ getHeight WRITE setHeight NOTIFY heightChanged)
+
+    Q_PROPERTY(QtFirebaseAdMobRequest* request READ request WRITE setRequest NOTIFY requestChanged)
+
+public:
+    enum Position
+    {
+        PositionTopCenter,
+        PositionTopLeft,
+        PositionTopRight,
+        PositionBottomCenter,
+        PositionBottomLeft,
+        PositionBottomRight
+    };
+    Q_ENUM(Position)
+
+    QtFirebaseAdMobNativeAd(QObject* parent = 0);
+    ~QtFirebaseAdMobNativeAd();
 
     bool ready();
     void setReady(bool ready);
@@ -525,8 +645,8 @@ private:
 
     QString __QTFIREBASE_ID;
     bool _ready;
-    bool _initializing;
     bool _loaded;
+    bool _initializing;
     bool _isFirstInit;
     bool _visible;
 

--- a/src/qtfirebaseadmob.h
+++ b/src/qtfirebaseadmob.h
@@ -306,7 +306,7 @@ private:
 
     QTimer *_initTimer;
 
-    firebase::admob::NativeExpressAdView* _banner;
+    firebase::admob::BannerView* _banner;
 
 };
 
@@ -425,7 +425,7 @@ private:
 
     QTimer *_initTimer;
 
-    firebase::admob::BannerView* _banner;
+    firebase::admob::NativeExpressAdView* _nativeAd;
 
 };
 

--- a/src/qtfirebaseanalytics.cpp
+++ b/src/qtfirebaseanalytics.cpp
@@ -125,13 +125,13 @@ void QtFirebaseAnalytics::logEvent(const QString &name, const QVariantMap bundle
         QString eventKey = i.key();
         QVariant variant = i.value();
 
-        if(variant.type() == QMetaType::Int) {
+        if(variant.type() == QVariant::Type(QMetaType::Int)) {
             parameters[index] = analytics::Parameter(keys.at(index).constData(), variant.toInt());
             qDebug() << this << "::logEvent" << "bundle parameter" << eventKey << ":" << variant.toInt();
-        } else if(variant.type() == QMetaType::Double) {
+        } else if(variant.type() == QVariant::Type(QMetaType::Double)) {
             parameters[index] = analytics::Parameter(keys.at(index).constData(),variant.toDouble());
             qDebug() << this << "::logEvent" << "bundle parameter" << eventKey << ":" << variant.toDouble();
-        } else if(variant.type() == QMetaType::QString) {
+        } else if(variant.type() == QVariant::Type(QMetaType::QString)) {
             strings.append(variant.toString().toLatin1());
             parameters[index] = analytics::Parameter(keys.at(index).constData(), strings.at(strings.size()-1).constData());
             qDebug() << this << "::logEvent" << "bundle parameter" << eventKey << ":" << strings.at(strings.size()-1);


### PR DESCRIPTION
- [Firebase Official doc for NativeExpressAd](https://firebase.google.com/docs/admob/cpp/native-express)
- Add `QtFirebaseNativeExpressAd` implementation, both in target.pri and fake.pri.
- Fix some compilation warnings 