### PR TITLE
Let application react to QGuiApplication::applicationStateChanged signal

### DIFF
--- a/src/qtfirebaseadmob.cpp
+++ b/src/qtfirebaseadmob.cpp
@@ -1,6 +1,6 @@
 #include "qtfirebaseadmob.h"
 
-#include <QGuiApplication>
+//#include <QGuiApplication>
 #include <qqmlfile.h>
 #include <QString>
 
@@ -485,7 +485,7 @@ QtFirebaseAdMobBanner::QtFirebaseAdMobBanner(QObject *parent) : QObject(parent)
 
     connect(qFirebase,&QtFirebase::futureEvent, this, &QtFirebaseAdMobBanner::onFutureEvent);
 
-    connect(qGuiApp,&QGuiApplication::applicationStateChanged, this, &QtFirebaseAdMobBanner::onApplicationStateChanged);
+//    connect(qGuiApp,&QGuiApplication::applicationStateChanged, this, &QtFirebaseAdMobBanner::onApplicationStateChanged);
 }
 
 QtFirebaseAdMobBanner::~QtFirebaseAdMobBanner()
@@ -907,7 +907,7 @@ QtFirebaseAdMobNativeExpressAd::QtFirebaseAdMobNativeExpressAd(QObject *parent) 
 
     connect(qFirebase,&QtFirebase::futureEvent, this, &QtFirebaseAdMobNativeExpressAd::onFutureEvent);
 
-    connect(qGuiApp,&QGuiApplication::applicationStateChanged, this, &QtFirebaseAdMobNativeExpressAd::onApplicationStateChanged);
+//    connect(qGuiApp,&QGuiApplication::applicationStateChanged, this, &QtFirebaseAdMobNativeExpressAd::onApplicationStateChanged);
 
 }
 

--- a/src/qtfirebaseadmob.h
+++ b/src/qtfirebaseadmob.h
@@ -645,8 +645,8 @@ private:
 
     QString __QTFIREBASE_ID;
     bool _ready;
-    bool _loaded;
     bool _initializing;
+    bool _loaded;
     bool _isFirstInit;
     bool _visible;
 


### PR DESCRIPTION
I have a android app which

1. I have several screens, each screen has different type Ads, one is Banner, another is NativeExpress, then a Interstitial between screen switching.
1. Currently `QtFirebaseAdMobBanner` and `QtFirebaseAdMobNativeExressAd`  connect there slots to `QGuiApplication::applicationStateChanged` in their constructor, which will lead to
   - Application cannot control when to display each kind of Ads by their logic. Every time switch the app to background and then foreground, or unlock the screen will make the Banner displayed again.
   - Interstitial Ad also will trigger the `QGuiApplication::applicationStateChanged` too.
1. So I suggest let app control the behavior on how to react to the `QGuiApplication::applicationStateChanged` signal.