### PR TITLE
Let application react to `QGuiApplication::applicationStateChanged` signal

### DIFF
--- a/fake/src/qtfirebaseadmob.h
+++ b/fake/src/qtfirebaseadmob.h
@@ -157,6 +157,17 @@ class QtFirebaseAdMobBanner : public QObject
     Q_PROPERTY(QtFirebaseAdMobRequest* request READ request WRITE setRequest NOTIFY requestChanged)
 
 public:
+    enum Position
+    {
+        PositionTopCenter,
+        PositionTopLeft,
+        PositionTopRight,
+        PositionBottomCenter,
+        PositionBottomLeft,
+        PositionBottomRight
+    };
+    Q_ENUM(Position)
+
     QtFirebaseAdMobBanner(QObject* parent = 0) { Q_UNUSED(parent); }
     ~QtFirebaseAdMobBanner() {}
 
@@ -208,12 +219,13 @@ public slots:
     void show() {}
     void hide() {}
     void moveTo(int x, int y) { Q_UNUSED(x); Q_UNUSED(y); }
+    void moveTo(int position) { Q_UNUSED(position); }
 };
 
 /*
  * AdMobNativeExpressAd
  */
-class AdMobNativeExpressAd : public QObject
+class QtFirebaseAdMobNativeExpressAd : public QObject
 {
     Q_OBJECT
 
@@ -232,8 +244,19 @@ class AdMobNativeExpressAd : public QObject
     Q_PROPERTY(QtFirebaseAdMobRequest* request READ request WRITE setRequest NOTIFY requestChanged)
 
 public:
-    AdMobNativeExpressAd(QObject* parent = 0) { Q_UNUSED(parent); }
-    ~AdMobNativeExpressAd() {}
+    enum Position
+    {
+        PositionTopCenter,
+        PositionTopLeft,
+        PositionTopRight,
+        PositionBottomCenter,
+        PositionBottomLeft,
+        PositionBottomRight
+    };
+    Q_ENUM(Position)
+
+    QtFirebaseAdMobNativeExpressAd(QObject* parent = 0) { Q_UNUSED(parent); }
+    ~QtFirebaseAdMobNativeExpressAd() {}
 
     bool ready() { return false; }
     void setReady(bool ready) { Q_UNUSED(ready); }
@@ -283,6 +306,7 @@ public slots:
     void show() {}
     void hide() {}
     void moveTo(int x, int y) { Q_UNUSED(x); Q_UNUSED(y); }
+    void moveTo(int position) { Q_UNUSED(position); }
 
 };
 

--- a/src/qtfirebaseadmob.cpp
+++ b/src/qtfirebaseadmob.cpp
@@ -1,6 +1,6 @@
 #include "qtfirebaseadmob.h"
 
-#include <QGuiApplication>
+//#include <QGuiApplication>
 #include <qqmlfile.h>
 #include <QString>
 
@@ -485,7 +485,7 @@ QtFirebaseAdMobBanner::QtFirebaseAdMobBanner(QObject *parent) : QObject(parent)
 
     connect(qFirebase,&QtFirebase::futureEvent, this, &QtFirebaseAdMobBanner::onFutureEvent);
 
-    connect(qGuiApp,&QGuiApplication::applicationStateChanged, this, &QtFirebaseAdMobBanner::onApplicationStateChanged);
+//    connect(qGuiApp,&QGuiApplication::applicationStateChanged, this, &QtFirebaseAdMobBanner::onApplicationStateChanged);
 }
 
 QtFirebaseAdMobBanner::~QtFirebaseAdMobBanner()
@@ -907,7 +907,7 @@ QtFirebaseAdMobNativeExpressAd::QtFirebaseAdMobNativeExpressAd(QObject *parent) 
 
     connect(qFirebase,&QtFirebase::futureEvent, this, &QtFirebaseAdMobNativeExpressAd::onFutureEvent);
 
-    connect(qGuiApp,&QGuiApplication::applicationStateChanged, this, &QtFirebaseAdMobNativeExpressAd::onApplicationStateChanged);
+//    connect(qGuiApp,&QGuiApplication::applicationStateChanged, this, &QtFirebaseAdMobNativeExpressAd::onApplicationStateChanged);
 
 }
 

--- a/src/qtfirebaseadmob.h
+++ b/src/qtfirebaseadmob.h
@@ -645,8 +645,8 @@ private:
 
     QString __QTFIREBASE_ID;
     bool _ready;
-    bool _loaded;
     bool _initializing;
+    bool _loaded;
     bool _isFirstInit;
     bool _visible;
 

--- a/src/qtfirebaseadmob.h
+++ b/src/qtfirebaseadmob.h
@@ -645,8 +645,8 @@ private:
 
     QString __QTFIREBASE_ID;
     bool _ready;
-    bool _initializing;
     bool _loaded;
+    bool _initializing;
     bool _isFirstInit;
     bool _visible;
 


### PR DESCRIPTION
Consider the following situation:

1. A App has several screens, each screen has different type Ads, one is Banner, another is NativeExpress, then a Interstitial between screen switching.
1. Currently `QtFirebaseAdMobBanner` and `QtFirebaseAdMobNativeExressAd`  connect there slots to `QGuiApplication::applicationStateChanged` in their constructor, which will lead to
   - Application cannot control when to display what kind of Ads by their logic. Every time switch the app to background and then foreground, or unlock the screen will make the Banner and NativeExpress Ads displayed again.
   - Closing an interstitial Ad also will also trigger the `QGuiApplication::applicationStateChanged` too.
1. So I suggest let app control the behavior on how to react to the `QGuiApplication::applicationStateChanged` signal by themself.