### PR TITLE
Delay init of QtFirebaseRemoteConfig

### DIFF
--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -124,6 +124,7 @@ signals:
 
 private slots:
     void addParameterInternal(const QString &name, const QVariant &defaultValue);
+    void beforeInit();
     void init();
     void onFutureEvent(QString eventId, firebase::FutureBase future);
 


### PR DESCRIPTION
Delay init of QtFirebaseRemoteConfig, let other objecst can catch the QtFirebaseRemote::readyChanged signal.