### PR TITLE
add missing auth/db registration in plugin functions

### DIFF
--- a/fake/src/qtfirebase_plugin.cpp
+++ b/fake/src/qtfirebase_plugin.cpp
@@ -18,8 +18,24 @@
 #include "src/qtfirebaseremoteconfig.h"
 # endif // QTFIREBASE_BUILD_REMOTE_CONFIG
 
+#if defined(QTFIREBASE_BUILD_ALL) || defined(QTFIREBASE_BUILD_AUTH)
+#include "src/qtfirebaseauth.h"
+# endif // QTFIREBASE_BUILD_AUTH
+
+#if defined(QTFIREBASE_BUILD_ALL) || defined(QTFIREBASE_BUILD_DATABASE)
+#include "src/qtfirebasedatabase.h"
+# endif // QTFIREBASE_BUILD_DATABASE
 
 #include <qqml.h>
+
+#if defined(QTFIREBASE_BUILD_ALL) || defined(QTFIREBASE_BUILD_DATABASE)
+static QObject *QtFirebaseDatabaseProvider(QQmlEngine *engine, QJSEngine *scriptEngine)
+{
+    Q_UNUSED(engine)
+    Q_UNUSED(scriptEngine)
+    return qFirebaseDb;
+}
+#endif
 
 void QtFirebasePlugin::registerTypes(const char *uri)
 {
@@ -44,6 +60,17 @@ void QtFirebasePlugin::registerTypes(const char *uri)
 
 #if defined(QTFIREBASE_BUILD_ALL) || defined(QTFIREBASE_BUILD_REMOTE_CONFIG)
     qmlRegisterType<QtFirebaseRemoteConfig>(uri, 1, 0, "RemoteConfig");
+#endif
+
+#if defined(QTFIREBASE_BUILD_ALL) || defined(QTFIREBASE_BUILD_AUTH)
+    qmlRegisterType<QtFirebaseAuth>("QtFirebase", 1, 0, "Auth");
+#endif
+
+#if defined(QTFIREBASE_BUILD_ALL) || defined(QTFIREBASE_BUILD_DATABASE)
+    qmlRegisterSingletonType<QtFirebaseDatabase>("QtFirebase", 1, 0, "Database", QtFirebaseDatabaseProvider);
+    qmlRegisterUncreatableType<QtFirebaseDatabaseQuery>("QtFirebase", 1, 0, "DatabaseQuery", "Get query object from DatabaseRequest, do not create it");
+    qmlRegisterType<QtFirebaseDatabaseRequest>("QtFirebase", 1, 0, "DatabaseRequest");
+    qmlRegisterUncreatableType<QtFirebaseDataSnapshot>("QtFirebase", 1, 0, "DataSnapshot", "Get snapshot object from DatabaseRequest, do not create it");
 #endif
 }
 

--- a/fake/src/qtfirebasedatabase.h
+++ b/fake/src/qtfirebasedatabase.h
@@ -12,7 +12,7 @@
 #define qFirebaseDatabase (static_cast<QtFirebaseDatabase*>(QtFirebaseDatabase::instance()))
 
 class QtFirebaseDatabaseRequest;
-class QtFirebaseDatabase : public QtFirebaseService
+class QtFirebaseDatabase : public QObject
 {
     Q_OBJECT
     typedef QSharedPointer<QtFirebaseDatabase> Ptr;

--- a/src/qtfirebase_plugin.cpp
+++ b/src/qtfirebase_plugin.cpp
@@ -27,12 +27,14 @@
 
 #include <qqml.h>
 
+#if defined(QTFIREBASE_BUILD_ALL) || defined(QTFIREBASE_BUILD_DATABASE)
 static QObject *QtFirebaseDatabaseProvider(QQmlEngine *engine, QJSEngine *scriptEngine)
 {
     Q_UNUSED(engine)
     Q_UNUSED(scriptEngine)
     return qFirebaseDb;
 }
+#endif
 
 
 void QtFirebasePlugin::registerTypes(const char *uri)


### PR DESCRIPTION
Added missing registration of auth/db classes for fake mode.
Fix compilation issue on windows
Added preprocessor defines for QtFirebaseDatabaseProvider function to skip it's compilation when no database requested in config