### PR TITLE
Change includes in fake to use brackets instead of quotes

### DIFF
--- a/fake/src/qtfirebase_plugin.cpp
+++ b/fake/src/qtfirebase_plugin.cpp
@@ -1,29 +1,29 @@
 #include "qtfirebase_plugin.h"
 
 #if defined(QTFIREBASE_BUILD_ALL) || defined(QTFIREBASE_BUILD_ANALYTICS)
-#include "src/qtfirebaseanalytics.h"
+#include <src/qtfirebaseanalytics.h>
 # endif // QTFIREBASE_BUILD_ANALYTICS
 
 #if defined(QTFIREBASE_BUILD_ALL) || defined(QTFIREBASE_BUILD_MESSAGING)
-#include "src/qtfirebasemessaging.h"
+#include <src/qtfirebasemessaging.h>
 # endif // QTFIREBASE_BUILD_MESSAGING
 
 
 #if defined(QTFIREBASE_BUILD_ALL) || defined(QTFIREBASE_BUILD_ADMOB)
-#include "src/qtfirebaseadmob.h"
+#include <src/qtfirebaseadmob.h>
 # endif // QTFIREBASE_BUILD_ADMOB
 
 
 #if defined(QTFIREBASE_BUILD_ALL) || defined(QTFIREBASE_BUILD_REMOTE_CONFIG)
-#include "src/qtfirebaseremoteconfig.h"
+#include <src/qtfirebaseremoteconfig.h>
 # endif // QTFIREBASE_BUILD_REMOTE_CONFIG
 
 #if defined(QTFIREBASE_BUILD_ALL) || defined(QTFIREBASE_BUILD_AUTH)
-#include "src/qtfirebaseauth.h"
+#include <src/qtfirebaseauth.h>
 # endif // QTFIREBASE_BUILD_AUTH
 
 #if defined(QTFIREBASE_BUILD_ALL) || defined(QTFIREBASE_BUILD_DATABASE)
-#include "src/qtfirebasedatabase.h"
+#include <src/qtfirebasedatabase.h>
 # endif // QTFIREBASE_BUILD_DATABASE
 
 #include <qqml.h>

--- a/fake/src/qtfirebaseadmob.h
+++ b/fake/src/qtfirebaseadmob.h
@@ -3,7 +3,7 @@
 
 #ifdef QTFIREBASE_BUILD_ADMOB
 
-#include "src/qtfirebase.h"
+#include <src/qtfirebase.h>
 
 #if defined(qFirebaseAdMob)
 #undef qFirebaseAdMob

--- a/fake/src/qtfirebaseanalytics.h
+++ b/fake/src/qtfirebaseanalytics.h
@@ -3,7 +3,7 @@
 
 #ifdef QTFIREBASE_BUILD_ANALYTICS
 
-#include "src/qtfirebase.h"
+#include <src/qtfirebase.h>
 
 #if defined(qFirebaseAnalytics)
 #undef qFirebaseAnalytics

--- a/fake/src/qtfirebaseauth.h
+++ b/fake/src/qtfirebaseauth.h
@@ -3,7 +3,7 @@
 #include <QObject>
 
 #ifdef QTFIREBASE_BUILD_AUTH
-#include "src/qtfirebase.h"
+#include <src/qtfirebase.h>
 #if defined(qFirebaseAuth)
 #undef qFirebaseAuth
 #endif

--- a/fake/src/qtfirebasedatabase.h
+++ b/fake/src/qtfirebasedatabase.h
@@ -4,8 +4,8 @@
 #include <QVariant>
 
 #ifdef QTFIREBASE_BUILD_DATABASE
-#include "src/qtfirebase.h"
-#include "src/qtfirebaseservice.h"
+#include <src/qtfirebase.h>
+#include <src/qtfirebaseservice.h>
 #if defined(qFirebaseDatabase)
 #undef qFirebaseDatabase
 #endif

--- a/fake/src/qtfirebasemessaging.h
+++ b/fake/src/qtfirebasemessaging.h
@@ -3,7 +3,7 @@
 
 #ifdef QTFIREBASE_BUILD_MESSAGING
 
-#include "src/qtfirebase.h"
+#include <src/qtfirebase.h>
 
 #if defined(qFirebaseMessaging)
 #undef qFirebaseMessaging

--- a/fake/src/qtfirebaseremoteconfig.h
+++ b/fake/src/qtfirebaseremoteconfig.h
@@ -5,7 +5,7 @@
 
 #ifdef QTFIREBASE_BUILD_REMOTE_CONFIG
 
-#include "src/qtfirebase.h"
+#include <src/qtfirebase.h>
 #include <QVariantMap>
 
 #if defined(qFirebaseRemoteConfig)


### PR DESCRIPTION
Fixes compilation problems with MSVC and Windows as target as it uses different search path resolution.

When compiling for kit "Desktop Qt 5.10.1 MSVC2015 64bit" I got the following error:
fatal error C1083: Cannot open include file: "firebase/app.h": No such file or directory

If I analyzed this correctly, this is due to the way the Microsoft preprocessor handles includes in quotes, especially the following:

"2) In the directories of the currently opened include files, in the reverse order in which they were opened. The search begins in the directory of the parent include file and continues upward through the directories of any grandparent include files." (https://msdn.microsoft.com/en-us/library/36k2cdd4.aspx)

When qtfirebase_register.cpp gets compiled, it includes qtfirebase_register.h. This then includes e.g. fake/src/qtfirebasemessaging.h which in turn includes "src/qtfirebase.h".
Due to the MS rules (it seems) that it does not pick up fake/src/qtfirebase.h but rather src/qtfirebase.h (as this exists from the location of the previously "opened" include qtfirebase_register.h).

GCC seems to behave different as it does not have the "currently opened include files" clause.

Changing the includes in fake/src/* to use brackets instead fixes the problem (for me), as the preprocessor then only checks the include directories given on the command line (which are set ok).