### PR TITLE
Don't re-create global Android activity reference

### DIFF
--- a/fake/src/qtfirebase.h
+++ b/fake/src/qtfirebase.h
@@ -15,12 +15,12 @@ class QtFirebase : public QObject
     Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
 
 public:
-    explicit QtFirebase(QObject* parent = 0) { Q_UNUSED(parent); }
+    explicit QtFirebase(QObject* parent = nullptr) { Q_UNUSED(parent); }
     ~QtFirebase() {}
 
     static QtFirebase *instance() {
-        if(self == 0)
-            self = new QtFirebase(0);
+        if(!self)
+            self = new QtFirebase();
         return self;
     }
 

--- a/fake/src/qtfirebaseanalytics.h
+++ b/fake/src/qtfirebaseanalytics.h
@@ -27,12 +27,12 @@ class QtFirebaseAnalytics : public QObject
     Q_PROPERTY(QString userId READ userId WRITE setUserId NOTIFY userIdChanged)
     Q_PROPERTY(QVariantList userProperties READ userProperties WRITE setUserProperties NOTIFY userPropertiesChanged)
 public:
-    explicit QtFirebaseAnalytics(QObject* parent = 0) { Q_UNUSED(parent); }
+    explicit QtFirebaseAnalytics(QObject* parent = nullptr) { Q_UNUSED(parent); }
     ~QtFirebaseAnalytics() {}
 
     static QtFirebaseAnalytics *instance() {
-        if(self == 0) {
-            self = new QtFirebaseAnalytics(0);
+        if(!self) {
+            self = new QtFirebaseAnalytics();
         }
         return self;
     }

--- a/fake/src/qtfirebasemessaging.h
+++ b/fake/src/qtfirebasemessaging.h
@@ -23,12 +23,12 @@ class QtFirebaseMessaging : public QObject
     Q_PROPERTY(QString token READ token NOTIFY tokenChanged)
 
 public:
-    explicit QtFirebaseMessaging(QObject* parent = 0) { Q_UNUSED(parent); }
+    explicit QtFirebaseMessaging(QObject* parent = nullptr) { Q_UNUSED(parent); }
     ~QtFirebaseMessaging() {}
 
     static QtFirebaseMessaging *instance() {
-        if(self == 0) {
-            self = new QtFirebaseMessaging(0);
+        if(!self) {
+            self = new QtFirebaseMessaging();
         }
         return self;
     }

--- a/fake/src/qtfirebaseservice.h
+++ b/fake/src/qtfirebaseservice.h
@@ -18,7 +18,7 @@ class QtFirebaseService: public QObject
     Q_OBJECT
     Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
 public:
-    explicit QtFirebaseService(QObject* parent = 0) { Q_UNUSED(parent); }
+    explicit QtFirebaseService(QObject* parent = nullptr) { Q_UNUSED(parent); }
     ~QtFirebaseService() {}
     bool ready() const { return true; }
     static QVariant fromFirebaseVariant(const QVariant& v) { return v; }

--- a/src/platformutils.cpp
+++ b/src/platformutils.cpp
@@ -1,5 +1,9 @@
 #include "platformutils.h"
 
+#if defined(Q_OS_ANDROID)
+jobject PlatformUtils::nativeWindow = nullptr;
+#endif
+
 /*
  * Google Play Services (only available under Android)
  */
@@ -35,9 +39,11 @@ jobject PlatformUtils::getNativeWindow()
 
     QAndroidJniObject activity = QtAndroid::androidActivity();
 
-    jobject globalActivity = env->NewGlobalRef(activity.object());
+    if (!nativeWindow) {
+        nativeWindow = env->NewGlobalRef(activity.object());
+    }
 
-    return globalActivity;
+    return nativeWindow;
 }
 #else
 void PlatformUtils::getNativeWindow()

--- a/src/platformutils.h
+++ b/src/platformutils.h
@@ -72,6 +72,11 @@ public:
     #else
     static void getNativeWindow();
     #endif
+
+private:
+    #if defined(Q_OS_ANDROID)
+    static jobject nativeWindow;
+    #endif
 };
 
 #endif // PLATFORM_UTILS_H

--- a/src/qtfirebase.cpp
+++ b/src/qtfirebase.cpp
@@ -3,7 +3,7 @@
 #include <QMutableMapIterator>
 #include <QThread>
 
-QtFirebase *QtFirebase::self = 0;
+QtFirebase *QtFirebase::self = nullptr;
 
 QtFirebase::QtFirebase(QObject* parent) : QObject(parent)
 {
@@ -30,13 +30,13 @@ QtFirebase::QtFirebase(QObject* parent) : QObject(parent)
 
 QtFirebase::~QtFirebase()
 {
-    self = 0;
+    self = nullptr;
     //delete _firebaseApp;
 }
 
 bool QtFirebase::checkInstance(const char *function)
 {
-    bool b = (QtFirebase::self != 0);
+    bool b = (QtFirebase::self != nullptr);
     if (!b)
         qWarning("QtFirebase::%s: Please instantiate the QtFirebase object first", function);
     return b;

--- a/src/qtfirebase.h
+++ b/src/qtfirebase.h
@@ -24,12 +24,12 @@ class QtFirebase : public QObject
     Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
 
 public:
-    explicit QtFirebase(QObject* parent = 0);
+    explicit QtFirebase(QObject* parent = nullptr);
     ~QtFirebase();
 
     static QtFirebase *instance() {
-        if(self == 0)
-            self = new QtFirebase(0);
+        if(!self)
+            self = new QtFirebase();
         return self;
     }
 
@@ -57,11 +57,11 @@ private:
     Q_DISABLE_COPY(QtFirebase)
 
     bool _ready = false;
-    firebase::App* _firebaseApp;
+    firebase::App* _firebaseApp = nullptr;
 
-    QTimer *_initTimer;
+    QTimer *_initTimer = nullptr;
 
-    QTimer *_futureWatchTimer;
+    QTimer *_futureWatchTimer = nullptr;
     QMap<QString, firebase::FutureBase> _futureMap;
 };
 

--- a/src/qtfirebaseanalytics.cpp
+++ b/src/qtfirebaseanalytics.cpp
@@ -4,11 +4,11 @@
 
 namespace analytics = ::firebase::analytics;
 
-QtFirebaseAnalytics *QtFirebaseAnalytics::self = 0;
+QtFirebaseAnalytics *QtFirebaseAnalytics::self = nullptr;
 
 QtFirebaseAnalytics::QtFirebaseAnalytics(QObject* parent) : QObject(parent)
 {
-    if(self == 0) {
+    if(!self) {
         self = this;
         qDebug() << self << "::QtFirebaseAnalytics" << "singleton";
     }
@@ -30,13 +30,13 @@ QtFirebaseAnalytics::~QtFirebaseAnalytics()
         qDebug() << self << "::~QtFirebaseAnalytics" << "shutting down";
         analytics::Terminate();
         _ready = false;
-        self = 0;
+        self = nullptr;
     }
 }
 
 bool QtFirebaseAnalytics::checkInstance(const char *function)
 {
-    bool b = (QtFirebaseAnalytics::self != 0);
+    bool b = (QtFirebaseAnalytics::self != nullptr);
     if (!b)
         qWarning("QtFirebaseAnalytics::%s: Please instantiate the QtFirebaseAnalytics object first", function);
     return b;
@@ -108,7 +108,7 @@ void QtFirebaseAnalytics::logEvent(const QString &name, const QString &parameter
     analytics::LogEvent(name.toUtf8().constData(), parameterName.toUtf8().constData(),parameterValue);
 }
 
-void QtFirebaseAnalytics::logEvent(const QString &name, const QVariantMap bundle)
+void QtFirebaseAnalytics::logEvent(const QString &name, const QVariantMap &bundle)
 {
     if(!_ready) {
         qDebug() << this << "::logEvent native part not ready";

--- a/src/qtfirebaseanalytics.h
+++ b/src/qtfirebaseanalytics.h
@@ -34,12 +34,12 @@ class QtFirebaseAnalytics : public QObject
     Q_PROPERTY(QVariantList userProperties READ userProperties WRITE setUserProperties NOTIFY userPropertiesChanged)
 
 public:
-    explicit QtFirebaseAnalytics(QObject* parent = 0);
+    explicit QtFirebaseAnalytics(QObject* parent = nullptr);
     ~QtFirebaseAnalytics();
 
     static QtFirebaseAnalytics *instance() {
-        if(self == 0) {
-            self = new QtFirebaseAnalytics(0);
+        if(!self) {
+            self = new QtFirebaseAnalytics();
             qDebug() << self << "::instance" << "singleton";
         }
         return self;
@@ -81,7 +81,7 @@ public slots:
     void logEvent(const QString &name, const QString &parameterName, const QString &parameterValue);
     void logEvent(const QString &name, const QString &parameterName, const double parameterValue);
     void logEvent(const QString &name, const QString &parameterName, const int parameterValue);
-    void logEvent(const QString &name, const QVariantMap bundle);
+    void logEvent(const QString &name, const QVariantMap &bundle);
     //void logEvent(const QString &name, const QString &parameterName, const int64_t parameterValue);
 
 private slots:

--- a/src/qtfirebasemessaging.cpp
+++ b/src/qtfirebasemessaging.cpp
@@ -11,7 +11,7 @@
 
 namespace messaging = ::firebase::messaging;
 
-QtFirebaseMessaging *QtFirebaseMessaging::self = 0;
+QtFirebaseMessaging *QtFirebaseMessaging::self = nullptr;
 
 QtFirebaseMessaging::QtFirebaseMessaging(QObject* parent)
     : QObject(parent)
@@ -19,7 +19,7 @@ QtFirebaseMessaging::QtFirebaseMessaging(QObject* parent)
 {
     __QTFIREBASE_ID = QString().sprintf("%8p", this);
 
-    if(self == 0) {
+    if(!self) {
         self = this;
         qDebug() << self << "::QtFirebaseMessaging" << "singleton";
     }
@@ -29,7 +29,7 @@ QtFirebaseMessaging::QtFirebaseMessaging(QObject* parent)
 
     if(qFirebase->ready()) {
         //Call init outside of constructor, otherwise signal readyChanged not emited
-        QTimer::singleShot(100, this, SLOT(init()));
+        QTimer::singleShot(100, this, &QtFirebaseMessaging::init);
     } else {
         connect(qFirebase,&QtFirebase::readyChanged, this, &QtFirebaseMessaging::init);
         qFirebase->requestInit();
@@ -58,7 +58,7 @@ void QtFirebaseMessaging::componentComplete()
 
 bool QtFirebaseMessaging::checkInstance(const char *function)
 {
-    bool b = (QtFirebaseMessaging::self != 0);
+    const bool b = (QtFirebaseMessaging::self != nullptr);
     if (!b)
         qWarning("QtFirebaseMessaging::%s: Please instantiate the QtFirebaseMessaging object first", function);
     return b;
@@ -79,7 +79,7 @@ void QtFirebaseMessaging::init()
     }
 }
 
-void QtFirebaseMessaging::onFutureEvent(QString eventId, firebase::FutureBase future)
+void QtFirebaseMessaging::onFutureEvent(const QString &eventId, const firebase::FutureBase &future)
 {
     if(!eventId.startsWith(__QTFIREBASE_ID))
         return;
@@ -124,7 +124,7 @@ QVariantMap QtFirebaseMessaging::data()
     return _data;
 }
 
-void QtFirebaseMessaging::setData(QVariantMap data)
+void QtFirebaseMessaging::setData(const QVariantMap &data)
 {
     if (_data != data) {
         _data = data;
@@ -138,7 +138,7 @@ QString QtFirebaseMessaging::token()
     return _token;
 }
 
-void QtFirebaseMessaging::setToken(QString token)
+void QtFirebaseMessaging::setToken(const QString &token)
 {
     if (_token != token) {
         _token = token;
@@ -244,7 +244,7 @@ QVariantMap MessageListener::data()
     return _data;
 }
 
-void MessageListener::setData(QVariantMap data)
+void MessageListener::setData(const QVariantMap &data)
 {
     if (_data != data) {
         _notifyMessageReceived = true;
@@ -262,7 +262,7 @@ QString MessageListener::token()
     return _token;
 }
 
-void MessageListener::setToken(QString token)
+void MessageListener::setToken(const QString &token)
 {
     if (_token != token) {
         _notifyTokenReceived = true;

--- a/src/qtfirebasemessaging.h
+++ b/src/qtfirebasemessaging.h
@@ -33,15 +33,15 @@ class QtFirebaseMessaging: public QObject, public QQmlParserStatus
     Q_PROPERTY(QString token READ token NOTIFY tokenChanged)
 
 public:
-    explicit QtFirebaseMessaging(QObject* parent = 0);
+    explicit QtFirebaseMessaging(QObject* parent = nullptr);
     ~QtFirebaseMessaging();
 
     void classBegin() override;
     void componentComplete() override;
 
     static QtFirebaseMessaging *instance() {
-        if(self == 0) {
-            self = new QtFirebaseMessaging(0);
+        if(!self) {
+            self = new QtFirebaseMessaging();
             qDebug() << self << "::instance" << "singleton";
         }
         return self;
@@ -53,14 +53,14 @@ public:
     void setReady(bool ready);
 
     QVariantMap data();
-    void setData(QVariantMap data);
+    void setData(const QVariantMap &data);
 
     QString token();
-    void setToken(QString token);
+    void setToken(const QString &token);
 
 private slots:
     void init();
-    void onFutureEvent(QString eventId, firebase::FutureBase future);
+    void onFutureEvent(const QString &eventId, const firebase::FutureBase &future);
     void getMessage();
     void getToken();
 
@@ -94,10 +94,10 @@ public:
     virtual void OnTokenReceived(const char* token) override;
 
     QVariantMap data();
-    void setData(QVariantMap data);
+    void setData(const QVariantMap &data);
 
     QString token();
-    void setToken(QString token);
+    void setToken(const QString &token);
 
 protected:
     void connectNotify(const QMetaMethod &signal) override;


### PR DESCRIPTION
Currently the global references are leaking on every call to getNativeWindow() on Android.