### PR TITLE
Make `future.OnCompletion` threadsafe

### DIFF
--- a/src/qtfirebaseadmob.cpp
+++ b/src/qtfirebaseadmob.cpp
@@ -543,17 +543,20 @@ void QtFirebaseAdMobBase::init()
         {
             future.OnCompletion([this](const firebase::FutureBase& completed_future)
             {
-                if(completed_future.error() != admob::kAdMobErrorNone) {
-                    qDebug() << this << "::init" << "initializing failed." << "ERROR: Action failed with error code and message: " << completed_future.error() << completed_future.error_message();
-                    emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
-                    _initializing = false;
-                }
-                else {
-                    qDebug() << this << "::init" << "initialized";
-                    _initializing = false;
-                    _isFirstInit = false;
-                    setReady(true);
-                }
+                // We are probably in a different thread right now.
+                QMetaObject::invokeMethod(this, [this, completed_future]() {
+                    if(completed_future.error() != admob::kAdMobErrorNone) {
+                        qDebug() << this << "::init" << "initializing failed." << "ERROR: Action failed with error code and message: " << completed_future.error() << completed_future.error_message();
+                        emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
+                        _initializing = false;
+                    }
+                    else {
+                        qDebug() << this << "::init" << "initialized";
+                        _initializing = false;
+                        _isFirstInit = false;
+                        setReady(true);
+                    }
+                });
             });
         }
     }
@@ -578,14 +581,17 @@ void QtFirebaseAdMobBase::load()
 
     future.OnCompletion([this](const firebase::FutureBase& completed_future)
     {
-        if(completed_future.error() != admob::kAdMobErrorNone) {
-            qWarning() << this << "::load" << "load failed" << "ERROR" << "code:" << completed_future.error() << "message:" << completed_future.error_message();
-            emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
-        }
-        else {
-            qDebug() << this << "::load loaded";
-            setLoaded(true);
-        }
+        // We are probably in a different thread right now.
+        QMetaObject::invokeMethod(this, [this, completed_future]() {
+            if(completed_future.error() != admob::kAdMobErrorNone) {
+                qWarning() << this << "::load" << "load failed" << "ERROR" << "code:" << completed_future.error() << "message:" << completed_future.error_message();
+                emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
+            }
+            else {
+                qDebug() << this << "::load loaded";
+                setLoaded(true);
+            }
+        });
     });
 }
 
@@ -641,22 +647,25 @@ void QtFirebaseAdMobBannerBase::moveTo(int x, int y)
 
         future.OnCompletion([this, x, y](const firebase::FutureBase& completed_future)
         {
-            if(completed_future.error() != admob::kAdMobErrorNone) {
-                qWarning() << this << "::moveTo " << x << " x " << y << " ERROR" << "code:" << completed_future.error() << "message:" << completed_future.error_message();
-                emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
-            }
-            else {
-                if(_x != x) {
-                    _x = x;
-                    emit xChanged();
+            // We are probably in a different thread right now.
+            QMetaObject::invokeMethod(this, [this, completed_future, x, y]() {
+                if(completed_future.error() != admob::kAdMobErrorNone) {
+                    qWarning() << this << "::moveTo " << x << " x " << y << " ERROR" << "code:" << completed_future.error() << "message:" << completed_future.error_message();
+                    emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
                 }
+                else {
+                    if(_x != x) {
+                        _x = x;
+                        emit xChanged();
+                    }
 
-                if(_y != y) {
-                    _y = y;
-                    emit yChanged();
+                    if(_y != y) {
+                        _y = y;
+                        emit yChanged();
+                    }
+                    qDebug() << this << "::moveTo moved to" << x << "," << y;
                 }
-                qDebug() << this << "::moveTo moved to" << x << "," << y;
-            }
+            });
         });
     }
 }
@@ -671,13 +680,16 @@ void QtFirebaseAdMobBannerBase::moveTo(Position position)
     auto future = moveToInternal(position);
     future.OnCompletion([this, position](const firebase::FutureBase& completed_future)
     {
-        if(completed_future.error() != admob::kAdMobErrorNone) {
-            qWarning() << this << "::moveTo " << position << " ERROR" << "code:" << completed_future.error() << "message:" << completed_future.error_message();
-            emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
-        }
-        else {
-            qDebug() << this << "::moveTo moved to" << position;
-        }
+        // We are probably in a different thread right now.
+        QMetaObject::invokeMethod(this, [this, completed_future, position]() {
+            if(completed_future.error() != admob::kAdMobErrorNone) {
+                qWarning() << this << "::moveTo " << position << " ERROR" << "code:" << completed_future.error() << "message:" << completed_future.error_message();
+                emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
+            }
+            else {
+                qDebug() << this << "::moveTo moved to" << position;
+            }
+        });
     });
 }
 
@@ -697,16 +709,19 @@ void QtFirebaseAdMobBannerBase::setVisible(bool visible)
         firebase::FutureBase future = setVisibleInternal(visible);
         future.OnCompletion([this, visible](const firebase::FutureBase& completed_future)
         {
-            if(completed_future.error() != admob::kAdMobErrorNone) {
-                qDebug() << this << "::setVisible" << visible <<  " ERROR code" << completed_future.error() << "message" << completed_future.error_message();
-                emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
-            }
-            else {
-                qDebug() << this << "::setVisible(" << visible << ")";
+            // We are probably in a different thread right now.
+            QMetaObject::invokeMethod(this, [this, completed_future, visible]() {
+                if(completed_future.error() != admob::kAdMobErrorNone) {
+                    qDebug() << this << "::setVisible" << visible <<  " ERROR code" << completed_future.error() << "message" << completed_future.error_message();
+                    emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
+                }
+                else {
+                    qDebug() << this << "::setVisible(" << visible << ")";
 
-                _visible = visible;
-                emit visibleChanged();
-            }
+                    _visible = visible;
+                    emit visibleChanged();
+                }
+            });
         });
     }
 }
@@ -976,29 +991,32 @@ firebase::FutureBase QtFirebaseAdMobInterstitial::initInternal()
     auto future = _interstitial->Initialize(static_cast<admob::AdParent>(_nativeUIElement), __adUnitIdByteArray.constData());
     future.OnCompletion([this](const firebase::FutureBase& completed_future)
     {
-        if(completed_future.error() != admob::kAdMobErrorNone) {
-            qDebug() << this << "::init" << "initializing failed." << "ERROR: Action failed with error code and message: " << completed_future.error() << completed_future.error_message();
-            emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
-            _initializing = false;
-        } else {
-            _initTimer->stop();
-            // NOTE don't delete it as we need it on iOS to re-initalize the whole mill after every load and show
-            //delete _initTimer;
+        // We are probably in a different thread right now.
+        QMetaObject::invokeMethod(this, [this, completed_future]() {
+            if(completed_future.error() != admob::kAdMobErrorNone) {
+                qDebug() << this << "::init" << "initializing failed." << "ERROR: Action failed with error code and message: " << completed_future.error() << completed_future.error_message();
+                emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
+                _initializing = false;
+            } else {
+                _initTimer->stop();
+                // NOTE don't delete it as we need it on iOS to re-initalize the whole mill after every load and show
+                //delete _initTimer;
 
-            qDebug() << this << "::init initialized";
-            _initializing = false;
-            _isFirstInit = false;
+                qDebug() << this << "::init initialized";
+                _initializing = false;
+                _isFirstInit = false;
 
-            // Add listener (can't be done before it's initialized)
-            auto cpy = _interstitialAdListener;
-            _interstitialAdListener = new QtFirebaseAdMobInterstitialAdListener(this);
-            _interstitial->SetListener(_interstitialAdListener);
-            if(cpy) {
-                delete cpy;
+                // Add listener (can't be done before it's initialized)
+                auto cpy = _interstitialAdListener;
+                _interstitialAdListener = new QtFirebaseAdMobInterstitialAdListener(this);
+                _interstitial->SetListener(_interstitialAdListener);
+                if(cpy) {
+                    delete cpy;
+                }
+
+                setReady(true);
             }
-
-            setReady(true);
-        }
+        });
     });
 
     return firebase::FutureBase(); // invalid future because we already handled it
@@ -1062,10 +1080,13 @@ void QtFirebaseAdMobInterstitial::show()
     firebase::FutureBase future = _interstitial->Show();
     future.OnCompletion([this](const firebase::FutureBase& completed_future)
     {
-        if(completed_future.error() != admob::kAdMobErrorNone) {
-            qDebug() << this << "::show" << "ERROR: Action failed with error code and message: " << completed_future.error() << completed_future.error_message();
-            emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
-        }
+        // We are probably in a different thread right now.
+        QMetaObject::invokeMethod(this, [this, completed_future]() {
+            if(completed_future.error() != admob::kAdMobErrorNone) {
+                qDebug() << this << "::show" << "ERROR: Action failed with error code and message: " << completed_future.error() << completed_future.error_message();
+                emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
+            }
+        });
     });
 }
 
@@ -1114,21 +1135,24 @@ firebase::FutureBase QtFirebaseAdMobRewardedVideoAd::initInternal()
 
     future.OnCompletion([this](const firebase::FutureBase& completed_future)
     {
-        if(completed_future.error() != admob::kAdMobErrorNone)
-        {
-            qDebug() << this << "::init initializing failed." << "ERROR: Action failed with error code and message: " << completed_future.error() << completed_future.error_message();
-            emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
-            _initializing = false;
-        }
-        else
-        {
-            _initTimer->stop();
-            qDebug() << this << "::init initialized";
-            _initializing = false;
-            _isFirstInit = false;
-            firebase::admob::rewarded_video::SetListener(this);
-            setReady(true);
-        }
+        // We are probably in a different thread right now.
+        QMetaObject::invokeMethod(this, [this, completed_future]() {
+            if(completed_future.error() != admob::kAdMobErrorNone)
+            {
+                qDebug() << this << "::init initializing failed." << "ERROR: Action failed with error code and message: " << completed_future.error() << completed_future.error_message();
+                emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
+                _initializing = false;
+            }
+            else
+            {
+                _initTimer->stop();
+                qDebug() << this << "::init initialized";
+                _initializing = false;
+                _isFirstInit = false;
+                firebase::admob::rewarded_video::SetListener(this);
+                setReady(true);
+            }
+        });
     });
 
     return firebase::FutureBase();
@@ -1206,11 +1230,14 @@ void QtFirebaseAdMobRewardedVideoAd::show()
 
     future.OnCompletion([this](const firebase::FutureBase& completed_future)
     {
-        if(completed_future.error() != admob::kAdMobErrorNone)
-        {
-            qDebug() << this << "::show " << "ERROR: Action failed with error code and message: " << completed_future.error() << completed_future.error_message();
-            emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
-        }
+        // We are probably in a different thread right now.
+        QMetaObject::invokeMethod(this, [this, completed_future]() {
+            if(completed_future.error() != admob::kAdMobErrorNone)
+            {
+                qDebug() << this << "::show " << "ERROR: Action failed with error code and message: " << completed_future.error() << completed_future.error_message();
+                emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
+            }
+        });
     });
 }
 


### PR DESCRIPTION
    - Fixed QObject::killTimer: timers cannot be stopped from another thread
    - Fixed another potential issues with threads