### PR TITLE
Fixed warning on init. Can't init without _appId, so init always fail…

### DIFF
--- a/src/qtfirebaseadmob.cpp
+++ b/src/qtfirebaseadmob.cpp
@@ -25,9 +25,7 @@ QtFirebaseAdMob::QtFirebaseAdMob(QObject* parent) : QObject(parent)
 
     __testDevices = 0;
 
-    if(qFirebase->ready())
-        init();
-    else {
+    if(!qFirebase->ready()) {
         connect(qFirebase,&QtFirebase::readyChanged, this, &QtFirebaseAdMob::init);
         qFirebase->requestInit();
     }


### PR DESCRIPTION
…s in constructor