### PR TITLE
Restore compatibility with Qt versions < 5.10

### DIFF
--- a/src/qtfirebaseadmob.cpp
+++ b/src/qtfirebaseadmob.cpp
@@ -544,7 +544,9 @@ void QtFirebaseAdMobBase::init()
             future.OnCompletion([this](const firebase::FutureBase& completed_future)
             {
                 // We are probably in a different thread right now.
+                #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
                 QMetaObject::invokeMethod(this, [this, completed_future]() {
+                #endif
                     if(completed_future.error() != admob::kAdMobErrorNone) {
                         qDebug() << this << "::init" << "initializing failed." << "ERROR: Action failed with error code and message: " << completed_future.error() << completed_future.error_message();
                         emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
@@ -556,7 +558,9 @@ void QtFirebaseAdMobBase::init()
                         _isFirstInit = false;
                         setReady(true);
                     }
+                #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
                 });
+                #endif
             });
         }
     }
@@ -582,7 +586,9 @@ void QtFirebaseAdMobBase::load()
     future.OnCompletion([this](const firebase::FutureBase& completed_future)
     {
         // We are probably in a different thread right now.
+        #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
         QMetaObject::invokeMethod(this, [this, completed_future]() {
+        #endif
             if(completed_future.error() != admob::kAdMobErrorNone) {
                 qWarning() << this << "::load" << "load failed" << "ERROR" << "code:" << completed_future.error() << "message:" << completed_future.error_message();
                 emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
@@ -591,7 +597,9 @@ void QtFirebaseAdMobBase::load()
                 qDebug() << this << "::load loaded";
                 setLoaded(true);
             }
+        #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
         });
+        #endif
     });
 }
 
@@ -648,7 +656,9 @@ void QtFirebaseAdMobBannerBase::moveTo(int x, int y)
         future.OnCompletion([this, x, y](const firebase::FutureBase& completed_future)
         {
             // We are probably in a different thread right now.
+            #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
             QMetaObject::invokeMethod(this, [this, completed_future, x, y]() {
+            #endif
                 if(completed_future.error() != admob::kAdMobErrorNone) {
                     qWarning() << this << "::moveTo " << x << " x " << y << " ERROR" << "code:" << completed_future.error() << "message:" << completed_future.error_message();
                     emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
@@ -665,7 +675,9 @@ void QtFirebaseAdMobBannerBase::moveTo(int x, int y)
                     }
                     qDebug() << this << "::moveTo moved to" << x << "," << y;
                 }
+            #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
             });
+            #endif
         });
     }
 }
@@ -681,7 +693,9 @@ void QtFirebaseAdMobBannerBase::moveTo(Position position)
     future.OnCompletion([this, position](const firebase::FutureBase& completed_future)
     {
         // We are probably in a different thread right now.
+        #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
         QMetaObject::invokeMethod(this, [this, completed_future, position]() {
+        #endif
             if(completed_future.error() != admob::kAdMobErrorNone) {
                 qWarning() << this << "::moveTo " << position << " ERROR" << "code:" << completed_future.error() << "message:" << completed_future.error_message();
                 emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
@@ -689,7 +703,9 @@ void QtFirebaseAdMobBannerBase::moveTo(Position position)
             else {
                 qDebug() << this << "::moveTo moved to" << position;
             }
+        #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
         });
+        #endif
     });
 }
 
@@ -710,7 +726,9 @@ void QtFirebaseAdMobBannerBase::setVisible(bool visible)
         future.OnCompletion([this, visible](const firebase::FutureBase& completed_future)
         {
             // We are probably in a different thread right now.
+            #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
             QMetaObject::invokeMethod(this, [this, completed_future, visible]() {
+            #endif
                 if(completed_future.error() != admob::kAdMobErrorNone) {
                     qDebug() << this << "::setVisible" << visible <<  " ERROR code" << completed_future.error() << "message" << completed_future.error_message();
                     emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
@@ -721,7 +739,9 @@ void QtFirebaseAdMobBannerBase::setVisible(bool visible)
                     _visible = visible;
                     emit visibleChanged();
                 }
+            #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
             });
+            #endif
         });
     }
 }
@@ -992,7 +1012,9 @@ firebase::FutureBase QtFirebaseAdMobInterstitial::initInternal()
     future.OnCompletion([this](const firebase::FutureBase& completed_future)
     {
         // We are probably in a different thread right now.
+        #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
         QMetaObject::invokeMethod(this, [this, completed_future]() {
+        #endif
             if(completed_future.error() != admob::kAdMobErrorNone) {
                 qDebug() << this << "::init" << "initializing failed." << "ERROR: Action failed with error code and message: " << completed_future.error() << completed_future.error_message();
                 emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
@@ -1016,7 +1038,9 @@ firebase::FutureBase QtFirebaseAdMobInterstitial::initInternal()
 
                 setReady(true);
             }
+        #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
         });
+        #endif
     });
 
     return firebase::FutureBase(); // invalid future because we already handled it
@@ -1081,12 +1105,16 @@ void QtFirebaseAdMobInterstitial::show()
     future.OnCompletion([this](const firebase::FutureBase& completed_future)
     {
         // We are probably in a different thread right now.
+        #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
         QMetaObject::invokeMethod(this, [this, completed_future]() {
+        #endif
             if(completed_future.error() != admob::kAdMobErrorNone) {
                 qDebug() << this << "::show" << "ERROR: Action failed with error code and message: " << completed_future.error() << completed_future.error_message();
                 emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
             }
+        #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
         });
+        #endif
     });
 }
 
@@ -1136,7 +1164,9 @@ firebase::FutureBase QtFirebaseAdMobRewardedVideoAd::initInternal()
     future.OnCompletion([this](const firebase::FutureBase& completed_future)
     {
         // We are probably in a different thread right now.
+        #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
         QMetaObject::invokeMethod(this, [this, completed_future]() {
+        #endif
             if(completed_future.error() != admob::kAdMobErrorNone)
             {
                 qDebug() << this << "::init initializing failed." << "ERROR: Action failed with error code and message: " << completed_future.error() << completed_future.error_message();
@@ -1152,7 +1182,9 @@ firebase::FutureBase QtFirebaseAdMobRewardedVideoAd::initInternal()
                 firebase::admob::rewarded_video::SetListener(this);
                 setReady(true);
             }
+        #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
         });
+        #endif
     });
 
     return firebase::FutureBase();
@@ -1231,13 +1263,17 @@ void QtFirebaseAdMobRewardedVideoAd::show()
     future.OnCompletion([this](const firebase::FutureBase& completed_future)
     {
         // We are probably in a different thread right now.
+        #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
         QMetaObject::invokeMethod(this, [this, completed_future]() {
+        #endif
             if(completed_future.error() != admob::kAdMobErrorNone)
             {
                 qDebug() << this << "::show " << "ERROR: Action failed with error code and message: " << completed_future.error() << completed_future.error_message();
                 emit error(completed_future.error(), QString(QString::fromUtf8(completed_future.error_message())));
             }
+        #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
         });
+        #endif
     });
 }
 


### PR DESCRIPTION
But Qt version < 5.10 is not threadsafe.

For complete port to Qt < 5.10 need to introduce a lot of new functions, that will looks ugly and complicated.

I haven't Qt < 5.10 installed, so not tested with Qt < 5.10, but should work.