### PR TITLE
Small change to enable clang compilation and linking

### DIFF
--- a/qtfirebase_target.pri
+++ b/qtfirebase_target.pri
@@ -60,6 +60,7 @@ android: {
     # c++:      LLVM libc++ runtime
     # gnustl:   GNU STL
     # stlport:  STLPort runtime
+    QTFIREBASE_STL_VARIANT = c++
     QTFIREBASE_SDK_LIBS_PATH = $$QTFIREBASE_SDK_PATH/libs/android/$$ANDROID_TARGET_ARCH/$$QTFIREBASE_STL_VARIANT
 
     DEPENDPATH += $$QTFIREBASE_SDK_LIBS_PATH

--- a/qtfirebase_target.pri
+++ b/qtfirebase_target.pri
@@ -56,7 +56,11 @@ android: {
     message("QtFirebase Android base")
     QT += androidextras gui-private
 
-    QTFIREBASE_SDK_LIBS_PATH = $$QTFIREBASE_SDK_PATH/libs/android/$$ANDROID_TARGET_ARCH/gnustl
+    # Specify the STL variant that is to be used in the app .pro file with the $$QTFIREBASE_STL_VARIANT variable
+    # c++:      LLVM libc++ runtime
+    # gnustl:   GNU STL
+    # stlport:  STLPort runtime
+    QTFIREBASE_SDK_LIBS_PATH = $$QTFIREBASE_SDK_PATH/libs/android/$$ANDROID_TARGET_ARCH/$$QTFIREBASE_STL_VARIANT
 
     DEPENDPATH += $$QTFIREBASE_SDK_LIBS_PATH
 }


### PR DESCRIPTION
As Android shifts towards clang, using clang will become the way to go. Due to some hardcoded reference to the gnustl version of the libraries error occurred when using clang to compile projects.
To make this more flexible, a QTFIREBASE_STL_VARIANT variable was introduced that can be set in the main app .pro file, a bit like the QTFIREBASE_DSK_PATH variable.
Setting the variable to "c++" the project will also compile with clang without linking errors (otherwise the wrong libraries are used)