### PR TITLE
made include works from non-project folder

### DIFF
--- a/qtfirebase_target.pri
+++ b/qtfirebase_target.pri
@@ -118,6 +118,7 @@ ios: {
 
     INCLUDEPATH += \
         $$QTFIREBASE_SDK_PATH/include \
+        $$QTFIREBASE_FRAMEWORKS_ROOT/../ \
         $$PWD/src \
         $$PWD/src/ios \
         \


### PR DESCRIPTION
Without 
$$QTFIREBASE_FRAMEWORKS_ROOT/../
added to include path there can be error like:
"Firebase/Firebase.h" not found.