### PR TITLE
Fix clang arc weak enabled

### DIFF
--- a/qtfirebase_target.pri
+++ b/qtfirebase_target.pri
@@ -118,6 +118,7 @@ ios: {
 
     INCLUDEPATH += \
         $$QTFIREBASE_SDK_PATH/include \
+        $$QTFIREBASE_FRAMEWORKS_ROOT/../ \
         $$PWD/src \
         $$PWD/src/ios \
         \

--- a/qtfirebase_target.pri
+++ b/qtfirebase_target.pri
@@ -118,7 +118,6 @@ ios: {
 
     INCLUDEPATH += \
         $$QTFIREBASE_SDK_PATH/include \
-        $$QTFIREBASE_FRAMEWORKS_ROOT/../ \
         $$PWD/src \
         $$PWD/src/ios \
         \

--- a/src/ios/platformutils.mm
+++ b/src/ios/platformutils.mm
@@ -20,7 +20,7 @@ void* PlatformUtils::getNativeWindow()
     //UIView* view = (__bridge UIView*)reinterpret_cast<void*>(window->winId());
     //qDebug() << "Getting UIView" << view;
 
-    return view;
+    return (__bridge void *)reinterpret_cast<UIView *>(view);
 
     //return QGuiApplication::platformNativeInterface()->nativeResourceForWindow("uiview", QGuiApplication::focusWindow());
 }


### PR DESCRIPTION
Fixes error if xcode options
CLANG_ENABLE_OBJC_WEAK=YES
CLANG_ENABLE_OBJC_ARC=YES
is added to xcode build settings.
This options is needed to use modern Objective-C with automatic memory management.