### PR TITLE
Remote config init

### DIFF
--- a/fake/src/qtfirebaseremoteconfig.h
+++ b/fake/src/qtfirebaseremoteconfig.h
@@ -18,7 +18,7 @@ class QtFirebaseRemoteConfig : public QObject
     Q_OBJECT
     Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
     Q_PROPERTY(QVariantMap parameters READ parameters WRITE setParameters NOTIFY parametersChanged)
-    Q_PROPERTY(long long cacheExpirationTime READ cacheExpirationTime WRITE setCacheExpirationTime NOTIFY cacheExpirationTimeChanged)
+    Q_PROPERTY(quint64 cacheExpirationTime READ cacheExpirationTime WRITE setCacheExpirationTime NOTIFY cacheExpirationTimeChanged)
 
 public:
     enum FetchFailure
@@ -46,8 +46,8 @@ public:
     QVariantMap parameters() const{return QVariantMap();}
     void setParameters(const QVariantMap& map){Q_UNUSED(map);}
 
-    long long cacheExpirationTime() const{return 0;}
-    void setCacheExpirationTime(long long timeMs){Q_UNUSED(timeMs);}
+    quint64 cacheExpirationTime() const{return 0;}
+    void setCacheExpirationTime(quint64 timeMs){Q_UNUSED(timeMs);}
 
 public slots:
     void addParameter(const QString &name, long long defaultValue){Q_UNUSED(name); Q_UNUSED(defaultValue);}

--- a/fake/src/qtfirebaseremoteconfig.h
+++ b/fake/src/qtfirebaseremoteconfig.h
@@ -29,13 +29,13 @@ public:
     };
     Q_ENUM(FetchFailure)
 
-    explicit QtFirebaseRemoteConfig(QObject *parent = 0){ Q_UNUSED(parent); }
+    explicit QtFirebaseRemoteConfig(QObject *parent = nullptr){ Q_UNUSED(parent); }
 
     ~QtFirebaseRemoteConfig() {}
 
     static QtFirebaseRemoteConfig *instance() {
-            if(self == 0) {
-                self = new QtFirebaseRemoteConfig(0);
+            if(self == nullptr) {
+                self = new QtFirebaseRemoteConfig(nullptr);
             }
             return self;
         }

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -2,7 +2,7 @@
 
 namespace remote_config = ::firebase::remote_config;
 
-QtFirebaseRemoteConfig *QtFirebaseRemoteConfig::self = 0;
+QtFirebaseRemoteConfig *QtFirebaseRemoteConfig::self = nullptr;
 
 QtFirebaseRemoteConfig::QtFirebaseRemoteConfig(QObject *parent) :
     QObject(parent),
@@ -11,9 +11,9 @@ QtFirebaseRemoteConfig::QtFirebaseRemoteConfig(QObject *parent) :
     _cacheExpirationTime(firebase::remote_config::kDefaultCacheExpiration*1000), // milliseconds
     __appId(nullptr)
 {
-    __QTFIREBASE_ID = QString().sprintf("%8p", this);
+    __QTFIREBASE_ID = QString().sprintf("%8p", static_cast<void*> (this));
 
-    if(self == 0)
+    if(self == nullptr)
     {
         self = this;
         qDebug() << self << "::QtFirebaseRemoteConfig" << "singleton";
@@ -44,7 +44,7 @@ QtFirebaseRemoteConfig::~QtFirebaseRemoteConfig() {
 
 bool QtFirebaseRemoteConfig::checkInstance(const char *function)
 {
-    bool b = (QtFirebaseRemoteConfig::self != 0);
+    bool b = (QtFirebaseRemoteConfig::self != nullptr);
     if(!b) qWarning("QtFirebaseRemoteConfig::%s:", function);
     return b;
 }

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -145,8 +145,7 @@ void QtFirebaseRemoteConfig::init()
     if(!_ready && !_initializing) {
         _initializing = true;
 
-        ::firebase::ModuleInitializer initializer;
-        auto future = initializer.Initialize(qFirebase->firebaseApp(), nullptr, [](::firebase::App* app, void*) {
+        auto future = _initializer.Initialize(qFirebase->firebaseApp(), nullptr, [](::firebase::App* app, void*) {
             // NOTE only write debug output here when developing
             // Causes crash on re-initialization (probably the "self" reference. And "this" can't be used in a lambda)
             //qDebug() << self << "::init" << "try to initialize Remote Config";
@@ -171,7 +170,7 @@ void QtFirebaseRemoteConfig::onFutureEvent(QString eventId, firebase::FutureBase
 
 void QtFirebaseRemoteConfig::onFutureEventInit(firebase::FutureBase &future)
 {
-    if (future.error() != firebase::kFutureStatusComplete) {
+    if (future.status() != firebase::kFutureStatusComplete) {
         qDebug() << this << "::onFutureEvent" << "initializing failed." << "ERROR: Action failed with error code and message: " << future.error() << future.error_message();
         _initializing = false;
         return;
@@ -180,6 +179,7 @@ void QtFirebaseRemoteConfig::onFutureEventInit(firebase::FutureBase &future)
     qDebug() << this << "::onFutureEvent initialized ok";
     _initializing = false;
     setReady(true);
+    future.Release();
 }
 
 void QtFirebaseRemoteConfig::onFutureEventFetch(firebase::FutureBase &future)

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -319,36 +319,34 @@ void QtFirebaseRemoteConfig::fetch(long long cacheExpirationInSeconds)
                 new remote_config::ConfigKeyValueVariant[filteredMap.size()]);
 
     __defaultsByteArrayList.clear();
-    uint index = 0;
+    size_t index = 0;
     for(QVariantMap::const_iterator it = filteredMap.begin(); it!=filteredMap.end();++it)
     {
+        __defaultsByteArrayList.insert(static_cast<int> (index),
+                                       QByteArray(it.key().toUtf8().data()));
+        const char* key = __defaultsByteArrayList.at(static_cast<int> (index)).constData();
         const QVariant& value = it.value();
 
-        __defaultsByteArrayList.insert(index,QByteArray(it.key().toUtf8().data()));
         if(value.type() == QVariant::Bool)
         {
-            defaults[index] = remote_config::ConfigKeyValueVariant{__defaultsByteArrayList.at(index).constData(),
-                    value.toBool()};
+            defaults[index] = remote_config::ConfigKeyValueVariant{key, value.toBool()};
         }
         else if(value.type() == QVariant::LongLong)
         {
-            defaults[index] = remote_config::ConfigKeyValueVariant{__defaultsByteArrayList.at(index).constData(),
-                    value.toLongLong()};
+            defaults[index] = remote_config::ConfigKeyValueVariant{key, value.toLongLong()};
         }
         else if(value.type() == QVariant::Int)
         {
-            defaults[index] = remote_config::ConfigKeyValueVariant{__defaultsByteArrayList.at(index).constData(),
-                    value.toInt()};
+            defaults[index] = remote_config::ConfigKeyValueVariant{key, value.toInt()};
         }
         else if(value.type() == QVariant::Double)
         {
-            defaults[index] = remote_config::ConfigKeyValueVariant{__defaultsByteArrayList.at(index).constData(),
-                    value.toDouble()};
+            defaults[index] = remote_config::ConfigKeyValueVariant{key, value.toDouble()};
         }
 
         else if(value.type() == QVariant::String)
         {
-            defaults[index] = remote_config::ConfigKeyValueVariant{__defaultsByteArrayList.at(index).constData(),
+            defaults[index] = remote_config::ConfigKeyValueVariant{key,
                     value.toString().toUtf8().constData()};
 
             //Code for data type
@@ -361,7 +359,7 @@ void QtFirebaseRemoteConfig::fetch(long long cacheExpirationInSeconds)
         index++;
     }
 
-    remote_config::SetDefaults(defaults.get(), filteredMap.size());
+    remote_config::SetDefaults(defaults.get(), static_cast<size_t> (filteredMap.size()));
 
     /*remote_config::SetConfigSetting(remote_config::kConfigSettingDeveloperMode, "1");
     if ((*remote_config::GetConfigSetting(remote_config::kConfigSettingDeveloperMode)

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -103,12 +103,12 @@ void QtFirebaseRemoteConfig::setParameters(const QVariantMap &map)
     emit parametersChanged();
 }
 
-long long QtFirebaseRemoteConfig::cacheExpirationTime() const
+quint64 QtFirebaseRemoteConfig::cacheExpirationTime() const
 {
     return _cacheExpirationTime;
 }
 
-void QtFirebaseRemoteConfig::setCacheExpirationTime(long long timeMs)
+void QtFirebaseRemoteConfig::setCacheExpirationTime(quint64 timeMs)
 {
     _cacheExpirationTime = timeMs;
     emit cacheExpirationTimeChanged();
@@ -287,7 +287,7 @@ void QtFirebaseRemoteConfig::fetch()
     fetch(_cacheExpirationTime<1000 ? 0 : _cacheExpirationTime/1000);
 }
 
-void QtFirebaseRemoteConfig::fetch(long long cacheExpirationInSeconds)
+void QtFirebaseRemoteConfig::fetch(quint64 cacheExpirationInSeconds)
 {
     if(_parameters.size() == 0)
     {

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -95,6 +95,7 @@ private:
     bool _initializing;
     QVariantMap _parameters;
     long long _cacheExpirationTime;
+    ::firebase::ModuleInitializer _initializer;
 
     QString _appId;
     QByteArray __appIdByteArray;

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -24,7 +24,7 @@ class QtFirebaseRemoteConfig : public QObject
     Q_PROPERTY(long long cacheExpirationTime READ cacheExpirationTime WRITE setCacheExpirationTime NOTIFY cacheExpirationTimeChanged)
 
 public:
-    explicit QtFirebaseRemoteConfig(QObject *parent = 0);
+    explicit QtFirebaseRemoteConfig(QObject *parent = nullptr);
     ~QtFirebaseRemoteConfig();
 
     enum FetchFailure
@@ -36,8 +36,8 @@ public:
     Q_ENUM(FetchFailure)
 
     static QtFirebaseRemoteConfig *instance() {
-        if(self == 0) {
-            self = new QtFirebaseRemoteConfig(0);
+        if(self == nullptr) {
+            self = new QtFirebaseRemoteConfig(nullptr);
             qDebug() << self << "::instance" << "singleton";
         }
         return self;

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -21,7 +21,7 @@ class QtFirebaseRemoteConfig : public QObject
     Q_OBJECT
     Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
     Q_PROPERTY(QVariantMap parameters READ parameters WRITE setParameters NOTIFY parametersChanged)
-    Q_PROPERTY(long long cacheExpirationTime READ cacheExpirationTime WRITE setCacheExpirationTime NOTIFY cacheExpirationTimeChanged)
+    Q_PROPERTY(quint64 cacheExpirationTime READ cacheExpirationTime WRITE setCacheExpirationTime NOTIFY cacheExpirationTimeChanged)
 
 public:
     explicit QtFirebaseRemoteConfig(QObject *parent = nullptr);
@@ -49,8 +49,8 @@ public:
     QVariantMap parameters() const;
     void setParameters(const QVariantMap& map);
 
-    long long cacheExpirationTime() const;
-    void setCacheExpirationTime(long long timeMs);
+    quint64 cacheExpirationTime() const;
+    void setCacheExpirationTime(quint64 timeMs);
 
 public slots:
     void addParameter(const QString &name, long long defaultValue);
@@ -84,7 +84,7 @@ private slots:
 
 private:
     void setReady(bool ready);
-    void fetch(long long cacheExpirationInSeconds);
+    void fetch(quint64 cacheExpirationInSeconds);
 
     static QtFirebaseRemoteConfig *self;
     Q_DISABLE_COPY(QtFirebaseRemoteConfig)
@@ -94,7 +94,7 @@ private:
     bool _ready;
     bool _initializing;
     QVariantMap _parameters;
-    long long _cacheExpirationTime;
+    quint64 _cacheExpirationTime;
     ::firebase::ModuleInitializer _initializer;
 
     QString _appId;


### PR DESCRIPTION
Fix for #103.

Module initializer object got destructed before the post-processing code was able to process the `Future`, resulting in invalid state.

I took the liberty to remove some compiler warnings on implicit casts. Also, I removed duplicated calls on the key when copying into default byte array.

Also, I'm not sure if `__defaultsByteArrayList` needs to be a class member?

Hope this helps.