### PR TITLE
Remove use of setMinimumSessionDuration which is deprecated

### DIFF
--- a/src/qtfirebaseanalytics.cpp
+++ b/src/qtfirebaseanalytics.cpp
@@ -292,13 +292,14 @@ unsigned int QtFirebaseAnalytics::minimumSessionDuration()
 
 void QtFirebaseAnalytics::setMinimumSessionDuration(unsigned int minimumSessionDuration)
 {
+    qWarning() << this << "::setMinimumSessionDuration is deprecated and no longer functional!";
+
     if(!_ready) {
         qDebug() << this << "::setMinimumSessionDuration native part not ready";
         return;
     }
 
     if (_minimumSessionDuration != minimumSessionDuration) {
-        analytics::SetMinimumSessionDuration(minimumSessionDuration);
         _minimumSessionDuration = minimumSessionDuration;
         qDebug() << self << "::setMinimumSessionDuration" << minimumSessionDuration;
         emit minimumSessionDurationChanged();


### PR DESCRIPTION
This generates warning and doesn't do anything anymore. I kept old QtFirebase logic for legacy reasons (in case someone has some logic tied to it :) )