### PR TITLE
Add setting session timeout

### DIFF
--- a/src/qtfirebaseanalytics.cpp
+++ b/src/qtfirebaseanalytics.cpp
@@ -248,6 +248,10 @@ void QtFirebaseAnalytics::setSessionTimeout(unsigned int sessionTimeout)
     if(_sessionTimeout != sessionTimeout) {
         _sessionTimeout = sessionTimeout;
         emit sessionTimeoutChanged();
+
+        if(_ready) {
+            analytics::SetSessionTimeoutDuration(_sessionTimeout);
+        }
     }
 }
 
@@ -320,5 +324,8 @@ void QtFirebaseAnalytics::init()
         qDebug() << self << "::init" << "native initialized";
         _initializing = false;
         setReady(true);
+
+        // Set current session duration timeout if it was set up already
+        analytics::SetSessionTimeoutDuration(_sessionTimeout);
     }
 }


### PR DESCRIPTION
I couldn't find setting up session timeout anywhere on QtFirebase. It's property that decides on how long single session will persist on Firebase.  
I've added setting it up on initialisation (in `init` method) and if native part is ready in `setSessionTimeout`.