### PR TITLE
RemoteConfig: Refactoring

### DIFF
--- a/src/qtfirebase.cpp
+++ b/src/qtfirebase.cpp
@@ -22,10 +22,6 @@ QtFirebase::QtFirebase(QObject* parent) : QObject(parent)
     _initTimer->setSingleShot(false);
     connect(_initTimer, &QTimer::timeout, self, &QtFirebase::requestInit);
     _initTimer->start(1000);
-
-    _futureWatchTimer = new QTimer(self);
-    _futureWatchTimer->setSingleShot(false);
-    connect(_futureWatchTimer, &QTimer::timeout, self, &QtFirebase::processEvents);
 }
 
 QtFirebase::~QtFirebase()
@@ -96,11 +92,12 @@ void QtFirebase::addFuture(const QString &eventId, const firebase::FutureBase &f
 
     _futureMap.insert(eventId,future);
 
-    //if(!_futureWatchTimer->isActive()) {
     qDebug() << self << "::addFuture" << "starting future watch";
-    _futureWatchTimer->start(1000);
-    //}
 
+    future.OnCompletion([ ](const firebase::FutureBase &) {
+        // callback may be in different thread
+        QTimer::singleShot(0, qFirebase, &QtFirebase::processEvents);
+    });
 }
 
 void QtFirebase::requestInit()
@@ -161,7 +158,6 @@ void QtFirebase::processEvents()
 
     if(_futureMap.isEmpty()) {
         qDebug() << self << "::processEvents" << "stopping future watch";
-        _futureWatchTimer->stop();
     }
 
 }

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -248,45 +248,57 @@ void QtFirebaseRemoteConfig::onFutureEventFetch(const firebase::FutureBase &futu
             QVariant::Double,
             QVariant::String,
         };
+
         const QVariant &value = it.value();
         const QString &key = it.key();
 
         const auto type = value.type();
-
         Q_ASSERT(types.contains(type));
-
-        if (type == QVariant::Bool) {
 #if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
+        switch (type) {
+        case QVariant::Bool:
             updatedParameters[key] = remoteConfigInstance->GetBoolean(key.toUtf8().constData());
-#else
-            updatedParameters[key] = remote_config::GetBoolean(key.toUtf8().constData());
-#endif
-        } else if (type == QVariant::Int) {
-#if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
+            break;
+        case QVariant::Int:
             updatedParameters[key] = static_cast<int>(remoteConfigInstance->GetLong(key.toUtf8().constData()));
-#else
-            updatedParameters[key] = static_cast<int>(remote_config::GetLong(key.toUtf8().constData()));
-#endif
-        } else if (type == QVariant::LongLong) {
-#if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
+            break;
+        case QVariant::LongLong:
             updatedParameters[key] = static_cast<long long>(remoteConfigInstance->GetLong(key.toUtf8().constData()));
-#else
-            updatedParameters[key] = static_cast<long long>(remote_config::GetLong(key.toUtf8().constData()));
-#endif
-        } else if (type == QVariant::Double) {
-#if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
+            break;
+        case QVariant::Double:
             updatedParameters[key] = remoteConfigInstance->GetDouble(key.toUtf8().constData());
-#else
-            updatedParameters[key] = remote_config::GetDouble(key.toUtf8().constData());
-#endif
-        } else if (type == QVariant::String) {
-#if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
+            break;
+        case QVariant::String: {
             const std::string result = remoteConfigInstance->GetString(key.toUtf8().constData());
-#else
-            const std::string result = remote_config::GetString(key.toUtf8().constData());
-#endif
             updatedParameters[key] = QString::fromUtf8(result.c_str());
+            break;
         }
+        default:
+            break;
+        }
+#else
+        switch (type) {
+        case QVariant::Bool:
+            updatedParameters[key] = remote_config::GetBoolean(key.toUtf8().constData());
+            break;
+        case QVariant::Int:
+            updatedParameters[key] = static_cast<int>(remote_config::GetLong(key.toUtf8().constData()));
+            break;
+        case QVariant::LongLong:
+            updatedParameters[key] = static_cast<long long>(remote_config::GetLong(key.toUtf8().constData()));
+            break;
+        case QVariant::Double:
+            updatedParameters[key] = remote_config::GetDouble(key.toUtf8().constData());
+            break;
+        case QVariant::String: {
+            const std::string result = remote_config::GetString(key.toUtf8().constData());
+            updatedParameters[key] = QString::fromUtf8(result.c_str());
+            break;
+        }
+        default:
+            break;
+        }
+#endif
     }
 
     setParameters(updatedParameters);

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -4,13 +4,6 @@ namespace remote_config = firebase::remote_config;
 
 QtFirebaseRemoteConfig *QtFirebaseRemoteConfig::self { nullptr };
 
-QtFirebaseRemoteConfig *QtFirebaseRemoteConfig::instance(QObject *parent)
-{
-    if (!self)
-        self = new QtFirebaseRemoteConfig(parent);
-    return self;
-}
-
 QtFirebaseRemoteConfig::QtFirebaseRemoteConfig(QObject *parent)
     : QObject(parent)
     , __QTFIREBASE_ID(QString().asprintf("%8p", static_cast<void *>(this)))

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -60,10 +60,10 @@ void QtFirebaseRemoteConfig::init()
     const auto app = qFirebase->firebaseApp();
 
 #if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
-    const auto future = firebase::remote_config::RemoteConfig::GetInstance(app)->EnsureInitialized();
+    const auto future = remote_config::RemoteConfig::GetInstance(app)->EnsureInitialized();
     qFirebase->addFuture(__QTFIREBASE_ID + QStringLiteral(".config.init"), future);
 #else
-    const auto initResult = firebase::remote_config::Initialize(*app);
+    const auto initResult = remote_config::Initialize(*app);
     if (initResult != firebase::kInitResultSuccess) {
         emit googlePlayServicesError();
         return;

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -252,30 +252,8 @@ void QtFirebaseRemoteConfig::onFutureEventFetch(firebase::FutureBase &future)
                 std::string result = remote_config::GetString(it.key().toUtf8().constData());
 #endif
                 updatedParameters[it.key()] = QString(QString::fromUtf8(result.c_str()));
-
-                //Code for data type
-                /*std::vector<unsigned char> out = remote_config::GetData(it.key().toUtf8().constData());
-                QByteArray data;
-                for (size_t i = 0; i < out.size(); ++i)
-                {
-                    data.append(out[i]);
-                }
-                updatedParameters[it.key()] = QString(data);*/
             }
         }
-
-        //SDK code to print out the keys
-        /*std::vector<std::string> keys = remote_config::GetKeys();
-        qDebug() << "QtFirebaseRemoteConfig GetKeys:";
-        for (auto s = keys.begin(); s != keys.end(); ++s)
-        {
-            qDebug() << s->c_str();
-        }
-        keys = remote_config::GetKeysByPrefix("TestD");
-        printf("GetKeysByPrefix(\"TestD\"):");
-        for (auto s = keys.begin(); s != keys.end(); ++s) {
-          printf("  %s", s->c_str());
-        }*/
 
         setParameters(updatedParameters);
     }
@@ -371,12 +349,6 @@ void QtFirebaseRemoteConfig::fetch(quint64 cacheExpirationInSeconds)
             stringsData += value.toString().toUtf8();
 
             defaults[index] = remote_config::ConfigKeyValueVariant{key, stringsData.last().constData()};
-
-            //Code for data type
-            /*QByteArray data = value.toString().toUtf8();
-            defaults[cnt] = remote_config::ConfigKeyValueVariant{
-                                it.key().toUtf8().constData(),
-                                firebase::Variant::FromMutableBlob(data.constData(), data.size())};*/
         }
 
         index++;
@@ -387,12 +359,6 @@ void QtFirebaseRemoteConfig::fetch(quint64 cacheExpirationInSeconds)
 #else
     remote_config::SetDefaults(defaults.get(), static_cast<size_t> (filteredMap.size()));
 #endif
-
-    /*remote_config::SetConfigSetting(remote_config::kConfigSettingDeveloperMode, "1");
-    if ((*remote_config::GetConfigSetting(remote_config::kConfigSettingDeveloperMode)
-                .c_str()) != '1') {
-        qDebug() << "Failed to enable developer mode";
-    }*/
 
     qDebug() << this << "::fetch" << "run fetching...";
 #if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -214,8 +214,8 @@ void QtFirebaseRemoteConfig::onFutureEventFetch(const firebase::FutureBase &futu
     }
 
 #if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
-    auto remoteConfigInstance = remote_config::RemoteConfig::GetInstance(qFirebase->firebaseApp());
-    const auto activateFuture = remoteConfigInstance->Activate();
+    auto instance = remote_config::RemoteConfig::GetInstance(qFirebase->firebaseApp());
+    const auto activateFuture = instance->Activate();
     qFirebase->waitForFutureCompletion(activateFuture);
 
     const bool fetchActivated = activateFuture.result() ? *activateFuture.result() : false;
@@ -225,7 +225,7 @@ void QtFirebaseRemoteConfig::onFutureEventFetch(const firebase::FutureBase &futu
     Q_UNUSED(fetchActivated)
 
 #if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
-    const remote_config::ConfigInfo &info = remoteConfigInstance->GetInfo();
+    const remote_config::ConfigInfo &info = instance->GetInfo();
 #else
     const remote_config::ConfigInfo &info = remote_config::GetInfo();
 #endif
@@ -256,19 +256,19 @@ void QtFirebaseRemoteConfig::onFutureEventFetch(const firebase::FutureBase &futu
 #if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
         switch (type) {
         case QVariant::Bool:
-            updatedParameters[key] = remoteConfigInstance->GetBoolean(keyStr);
+            updatedParameters[key] = instance->GetBoolean(keyStr);
             break;
         case QVariant::Int:
-            updatedParameters[key] = static_cast<int>(remoteConfigInstance->GetLong(keyStr));
+            updatedParameters[key] = static_cast<int>(instance->GetLong(keyStr));
             break;
         case QVariant::LongLong:
-            updatedParameters[key] = static_cast<long long>(remoteConfigInstance->GetLong(keyStr));
+            updatedParameters[key] = static_cast<long long>(instance->GetLong(keyStr));
             break;
         case QVariant::Double:
-            updatedParameters[key] = remoteConfigInstance->GetDouble(keyStr);
+            updatedParameters[key] = instance->GetDouble(keyStr);
             break;
         case QVariant::String:
-            updatedParameters[key] = QString::fromStdString(remoteConfigInstance->GetString(keyStr));
+            updatedParameters[key] = QString::fromStdString(instance->GetString(keyStr));
             break;
         default:
             break;

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -225,9 +225,10 @@ void QtFirebaseRemoteConfig::onFutureEventFetch(const firebase::FutureBase &futu
     QVariantMap updatedParameters;
     for (auto it = _parameters.cbegin(); it != _parameters.cend(); ++it) {
         const auto type = it.value().type();
-        const QString &key = it.key();
+        const auto &key = it.key();
 
-        const auto keyStr = key.toUtf8().constData();
+        const auto keyUtf8 = key.toUtf8();
+        const auto keyStr = keyUtf8.constData();
 
 #if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
         switch (type) {

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -1,8 +1,5 @@
 #include "qtfirebaseremoteconfig.h"
 
-#include <QSet>
-#include <memory>
-
 namespace remote_config = firebase::remote_config;
 
 QtFirebaseRemoteConfig *QtFirebaseRemoteConfig::self { nullptr };

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -113,40 +113,6 @@ void QtFirebaseRemoteConfig::setCacheExpirationTime(quint64 ms)
     emit cacheExpirationTimeChanged();
 }
 
-void QtFirebaseRemoteConfig::addParameterInternal(const QString &name, const QVariant &defaultValue)
-{
-    _parameters[name] = defaultValue;
-}
-
-QVariant QtFirebaseRemoteConfig::getParameterValue(const QString &name) const
-{
-    if(_parameters.contains(name))
-    {
-        return _parameters[name];
-    }
-    return _parameters[name];
-}
-
-void QtFirebaseRemoteConfig::addParameter(const QString &name, long long defaultValue)
-{
-    addParameterInternal(name, defaultValue);
-}
-
-void QtFirebaseRemoteConfig::addParameter(const QString &name, double defaultValue)
-{
-    addParameterInternal(name, defaultValue);
-}
-
-void QtFirebaseRemoteConfig::addParameter(const QString &name, const QString &defaultValue)
-{
-    addParameterInternal(name, defaultValue);
-}
-
-void QtFirebaseRemoteConfig::addParameter(const QString &name, bool defaultValue)
-{
-    addParameterInternal(name, defaultValue);
-}
-
 void QtFirebaseRemoteConfig::onFutureEvent(QString eventId, firebase::FutureBase future)
 {
     if(!eventId.startsWith(__QTFIREBASE_ID))
@@ -275,11 +241,6 @@ void QtFirebaseRemoteConfig::onFutureEventFetch(firebase::FutureBase &future)
     future.Release();
 }
 
-void QtFirebaseRemoteConfig::fetch()
-{
-    fetch(_cacheExpirationTime<1000 ? 0 : _cacheExpirationTime/1000);
-}
-
 void QtFirebaseRemoteConfig::fetch(quint64 cacheExpirationInSeconds)
 {
     if(_parameters.size() == 0)
@@ -367,9 +328,4 @@ void QtFirebaseRemoteConfig::fetch(quint64 cacheExpirationInSeconds)
     auto future = remote_config::Fetch(cacheExpirationInSeconds);
 #endif
     qFirebase->addFuture(__QTFIREBASE_ID + QStringLiteral(".config.fetch"), future);
-}
-
-void QtFirebaseRemoteConfig::fetchNow()
-{
-    fetch(0);
 }

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -127,6 +127,78 @@ void QtFirebaseRemoteConfig::setCacheExpirationTime(quint64 ms)
     emit cacheExpirationTimeChanged();
 }
 
+void QtFirebaseRemoteConfig::fetch(quint64 cacheExpirationInSeconds)
+{
+    if (!_ready)
+        return;
+
+    if (_parameters.isEmpty())
+        return;
+
+    QVariantMap filteredMap;
+    for (auto it = _parameters.cbegin(); it != _parameters.cend(); ++it) {
+        static QSet<QVariant::Type> types {
+            QVariant::Bool,
+            QVariant::Int,
+            QVariant::LongLong,
+            QVariant::Double,
+            QVariant::String,
+        };
+        const auto &value = it.value();
+        const auto type = value.type();
+        if (types.contains(type))
+            filteredMap[it.key()] = value;
+    }
+
+    QByteArrayList stringsData;
+
+    std::unique_ptr<remote_config::ConfigKeyValueVariant[]> defaults(new remote_config::ConfigKeyValueVariant[filteredMap.size()]);
+    size_t index = 0;
+
+    __defaultsByteArrayList.clear();
+    for (auto it = filteredMap.cbegin(); it != filteredMap.cend(); ++it) {
+        __defaultsByteArrayList.insert(static_cast<int>(index), QByteArray(it.key().toUtf8()));
+        const auto key = __defaultsByteArrayList.at(static_cast<int>(index)).constData();
+
+        const auto &value = it.value();
+        const auto type = value.type();
+
+        switch (type) {
+        case QVariant::Bool:
+            defaults[index] = remote_config::ConfigKeyValueVariant { key, value.toBool() };
+            break;
+        case QVariant::Int:
+            defaults[index] = remote_config::ConfigKeyValueVariant { key, value.toInt() };
+            break;
+        case QVariant::LongLong:
+            defaults[index] = remote_config::ConfigKeyValueVariant { key, static_cast<int64_t>(value.toLongLong()) };
+            break;
+        case QVariant::Double:
+            defaults[index] = remote_config::ConfigKeyValueVariant { key, value.toDouble() };
+            break;
+        case QVariant::String:
+            stringsData += value.toString().toUtf8();
+            defaults[index] = remote_config::ConfigKeyValueVariant { key, stringsData.last().constData() };
+            break;
+        default:
+            break;
+        }
+
+        index++;
+    }
+
+#if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
+    auto instance = remote_config::RemoteConfig::GetInstance(qFirebase->firebaseApp());
+    instance->SetDefaults(defaults.get(), static_cast<size_t>(filteredMap.size()));
+    const auto future = instance->Fetch(cacheExpirationInSeconds);
+#else
+    remote_config::SetDefaults(defaults.get(), static_cast<size_t>(filteredMap.size()));
+    const auto future = remote_config::Fetch(cacheExpirationInSeconds);
+#endif
+
+    qFirebase->addFuture(__QTFIREBASE_ID + QStringLiteral(".config.fetch"), future);
+}
+
 void QtFirebaseRemoteConfig::onFutureEventFetch(const firebase::FutureBase &future)
 {
     if(future.status() != firebase::kFutureStatusComplete)
@@ -237,76 +309,4 @@ void QtFirebaseRemoteConfig::onFutureEventFetch(const firebase::FutureBase &futu
             emit error(FetchFailureReasonError, QStringLiteral("Failure reason is unknown"));
         }
     }
-}
-
-void QtFirebaseRemoteConfig::fetch(quint64 cacheExpirationInSeconds)
-{
-    if (!_ready)
-        return;
-
-    if (_parameters.isEmpty())
-        return;
-
-    QVariantMap filteredMap;
-    for (auto it = _parameters.cbegin(); it != _parameters.cend(); ++it) {
-        static QSet<QVariant::Type> types {
-            QVariant::Bool,
-            QVariant::Int,
-            QVariant::LongLong,
-            QVariant::Double,
-            QVariant::String,
-        };
-        const auto &value = it.value();
-        const auto type = value.type();
-        if (types.contains(type))
-            filteredMap[it.key()] = value;
-    }
-
-    QByteArrayList stringsData;
-
-    std::unique_ptr<remote_config::ConfigKeyValueVariant[]> defaults(new remote_config::ConfigKeyValueVariant[filteredMap.size()]);
-    size_t index = 0;
-
-    __defaultsByteArrayList.clear();
-    for (auto it = filteredMap.cbegin(); it != filteredMap.cend(); ++it) {
-        __defaultsByteArrayList.insert(static_cast<int>(index), QByteArray(it.key().toUtf8()));
-        const auto key = __defaultsByteArrayList.at(static_cast<int>(index)).constData();
-
-        const auto &value = it.value();
-        const auto type = value.type();
-
-        switch (type) {
-        case QVariant::Bool:
-            defaults[index] = remote_config::ConfigKeyValueVariant { key, value.toBool() };
-            break;
-        case QVariant::Int:
-            defaults[index] = remote_config::ConfigKeyValueVariant { key, value.toInt() };
-            break;
-        case QVariant::LongLong:
-            defaults[index] = remote_config::ConfigKeyValueVariant { key, static_cast<int64_t>(value.toLongLong()) };
-            break;
-        case QVariant::Double:
-            defaults[index] = remote_config::ConfigKeyValueVariant { key, value.toDouble() };
-            break;
-        case QVariant::String:
-            stringsData += value.toString().toUtf8();
-            defaults[index] = remote_config::ConfigKeyValueVariant { key, stringsData.last().constData() };
-            break;
-        default:
-            break;
-        }
-
-        index++;
-    }
-
-#if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
-    auto instance = remote_config::RemoteConfig::GetInstance(qFirebase->firebaseApp());
-    instance->SetDefaults(defaults.get(), static_cast<size_t>(filteredMap.size()));
-    const auto future = instance->Fetch(cacheExpirationInSeconds);
-#else
-    remote_config::SetDefaults(defaults.get(), static_cast<size_t>(filteredMap.size()));
-    const auto future = remote_config::Fetch(cacheExpirationInSeconds);
-#endif
-
-    qFirebase->addFuture(__QTFIREBASE_ID + QStringLiteral(".config.fetch"), future);
 }

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -135,26 +135,12 @@ void QtFirebaseRemoteConfig::fetch(quint64 cacheExpirationInSeconds)
     if (_parameters.isEmpty())
         return;
 
-    QVariantMap filteredMap;
-    for (auto it = _parameters.cbegin(); it != _parameters.cend(); ++it) {
-        static QSet<QVariant::Type> types {
-            QVariant::Bool,
-            QVariant::Int,
-            QVariant::LongLong,
-            QVariant::Double,
-            QVariant::String,
-        };
-        const auto &value = it.value();
-        if (types.contains(value.type()))
-            filteredMap[it.key()] = value;
-    }
-
     QByteArrayList keysData;
     QByteArrayList stringsData;
 
     QVector<remote_config::ConfigKeyValueVariant> defaults;
-    defaults.reserve(filteredMap.size());
-    for (auto it = filteredMap.cbegin(); it != filteredMap.cend(); ++it) {
+    defaults.reserve(_parameters.size());
+    for (auto it = _parameters.cbegin(); it != _parameters.cend(); ++it) {
         keysData << it.key().toUtf8();
         const auto key = keysData.last().constData();
 
@@ -240,18 +226,8 @@ void QtFirebaseRemoteConfig::onFutureEventFetch(const firebase::FutureBase &futu
 
     QVariantMap updatedParameters;
     for (auto it = _parameters.cbegin(); it != _parameters.cend(); ++it) {
-        static QSet<QVariant::Type> types {
-            QVariant::Bool,
-            QVariant::Int,
-            QVariant::LongLong,
-            QVariant::Double,
-            QVariant::String,
-        };
-
-        const QVariant &value = it.value();
+        const auto type = it.value().type();
         const QString &key = it.key();
-        const auto type = value.type();
-        Q_ASSERT(types.contains(type));
 
         const auto keyStr = key.toUtf8().constData();
 

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -250,50 +250,48 @@ void QtFirebaseRemoteConfig::onFutureEventFetch(const firebase::FutureBase &futu
 
         const QVariant &value = it.value();
         const QString &key = it.key();
-
         const auto type = value.type();
         Q_ASSERT(types.contains(type));
+
+        const auto keyStr = key.toUtf8().constData();
+
 #if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
         switch (type) {
         case QVariant::Bool:
-            updatedParameters[key] = remoteConfigInstance->GetBoolean(key.toUtf8().constData());
+            updatedParameters[key] = remoteConfigInstance->GetBoolean(keyStr);
             break;
         case QVariant::Int:
-            updatedParameters[key] = static_cast<int>(remoteConfigInstance->GetLong(key.toUtf8().constData()));
+            updatedParameters[key] = static_cast<int>(remoteConfigInstance->GetLong(keyStr));
             break;
         case QVariant::LongLong:
-            updatedParameters[key] = static_cast<long long>(remoteConfigInstance->GetLong(key.toUtf8().constData()));
+            updatedParameters[key] = static_cast<long long>(remoteConfigInstance->GetLong(keyStr));
             break;
         case QVariant::Double:
-            updatedParameters[key] = remoteConfigInstance->GetDouble(key.toUtf8().constData());
+            updatedParameters[key] = remoteConfigInstance->GetDouble(keyStr);
             break;
-        case QVariant::String: {
-            const std::string result = remoteConfigInstance->GetString(key.toUtf8().constData());
-            updatedParameters[key] = QString::fromUtf8(result.c_str());
+        case QVariant::String:
+            updatedParameters[key] = QString::fromStdString(remoteConfigInstance->GetString(keyStr));
             break;
-        }
         default:
             break;
         }
 #else
         switch (type) {
         case QVariant::Bool:
-            updatedParameters[key] = remote_config::GetBoolean(key.toUtf8().constData());
+            updatedParameters[key] = remote_config::GetBoolean(keyStr);
             break;
         case QVariant::Int:
-            updatedParameters[key] = static_cast<int>(remote_config::GetLong(key.toUtf8().constData()));
+            updatedParameters[key] = static_cast<int>(remote_config::GetLong(keyStr));
             break;
         case QVariant::LongLong:
-            updatedParameters[key] = static_cast<long long>(remote_config::GetLong(key.toUtf8().constData()));
+            updatedParameters[key] = static_cast<long long>(remote_config::GetLong(keyStr));
             break;
         case QVariant::Double:
-            updatedParameters[key] = remote_config::GetDouble(key.toUtf8().constData());
+            updatedParameters[key] = remote_config::GetDouble(keyStr);
             break;
-        case QVariant::String: {
-            const std::string result = remote_config::GetString(key.toUtf8().constData());
-            updatedParameters[key] = QString::fromUtf8(result.c_str());
+        case QVariant::String:
+            updatedParameters[key] = QString::fromStdString(remote_config::GetString(keyStr));
             break;
-        }
         default:
             break;
         }

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -142,11 +142,11 @@ void QtFirebaseRemoteConfig::fetch(quint64 cacheExpirationInSeconds)
     defaults.reserve(_parameters.size());
     for (auto it = _parameters.cbegin(); it != _parameters.cend(); ++it) {
         keysData << it.key().toUtf8();
+
         const auto key = keysData.last().constData();
-
         const auto &value = it.value();
-        const auto type = value.type();
 
+        const auto type = value.type();
         switch (type) {
         case QVariant::Bool:
             defaults << remote_config::ConfigKeyValueVariant { key, value.toBool() };
@@ -224,12 +224,11 @@ void QtFirebaseRemoteConfig::onFutureEventFetch(const firebase::FutureBase &futu
 
     QVariantMap updatedParameters;
     for (auto it = _parameters.cbegin(); it != _parameters.cend(); ++it) {
-        const auto type = it.value().type();
         const auto &key = it.key();
-
         const auto keyUtf8 = key.toUtf8();
         const auto keyStr = keyUtf8.constData();
 
+        const auto type = it.value().type();
 #if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
         switch (type) {
         case QVariant::Bool:

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -15,15 +15,7 @@ QtFirebaseRemoteConfig *QtFirebaseRemoteConfig::instance(QObject *parent)
 
 QtFirebaseRemoteConfig::QtFirebaseRemoteConfig(QObject *parent)
     : QObject(parent)
-    , __QTFIREBASE_ID(QString().asprintf("%8p", static_cast<void*> (this)))
-    , _ready(false)
-    , _initializing(false)
-    , _parameters()
-    , _cacheExpirationTime(firebase::remote_config::kDefaultCacheExpiration*1000) // milliseconds
-    , _appId()
-    , __appIdByteArray()
-    , __defaultsByteArrayList()
-    , __appId(nullptr)
+    , __QTFIREBASE_ID(QString().asprintf("%8p", static_cast<void *>(this)))
 {
     // deny multiple instances
     Q_ASSERT(!self);
@@ -113,7 +105,7 @@ void QtFirebaseRemoteConfig::setCacheExpirationTime(quint64 ms)
     emit cacheExpirationTimeChanged();
 }
 
-void QtFirebaseRemoteConfig::onFutureEvent(QString eventId, firebase::FutureBase future)
+void QtFirebaseRemoteConfig::onFutureEvent(const QString &eventId, firebase::FutureBase future)
 {
     if(!eventId.startsWith(__QTFIREBASE_ID))
         return;
@@ -126,7 +118,7 @@ void QtFirebaseRemoteConfig::onFutureEvent(QString eventId, firebase::FutureBase
     future.Release();
 }
 
-void QtFirebaseRemoteConfig::onFutureEventFetch(firebase::FutureBase &future)
+void QtFirebaseRemoteConfig::onFutureEventFetch(const firebase::FutureBase &future)
 {
     if(future.status() != firebase::kFutureStatusComplete)
     {
@@ -238,7 +230,6 @@ void QtFirebaseRemoteConfig::onFutureEventFetch(firebase::FutureBase &future)
             emit error(FetchFailureReasonError, QStringLiteral("Failure reason is unknown"));
         }
     }
-    future.Release();
 }
 
 void QtFirebaseRemoteConfig::fetch(quint64 cacheExpirationInSeconds)

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -51,13 +51,6 @@ QtFirebaseRemoteConfig::~QtFirebaseRemoteConfig()
         self = nullptr;
 }
 
-bool QtFirebaseRemoteConfig::checkInstance(const char *function)
-{
-    bool b = (QtFirebaseRemoteConfig::self != nullptr);
-    if(!b) qWarning("QtFirebaseRemoteConfig::%s:", function);
-    return b;
-}
-
 void QtFirebaseRemoteConfig::addParameterInternal(const QString &name, const QVariant &defaultValue)
 {
     _parameters[name] = defaultValue;

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -147,28 +147,26 @@ void QtFirebaseRemoteConfig::fetch(quint64 cacheExpirationInSeconds)
         const auto &value = it.value();
         const auto type = value.type();
 
-        remote_config::ConfigKeyValueVariant variant;
         switch (type) {
         case QVariant::Bool:
-            variant = remote_config::ConfigKeyValueVariant { key, value.toBool() };
+            defaults << remote_config::ConfigKeyValueVariant { key, value.toBool() };
             break;
         case QVariant::Int:
-            variant = remote_config::ConfigKeyValueVariant { key, value.toInt() };
+            defaults << remote_config::ConfigKeyValueVariant { key, value.toInt() };
             break;
         case QVariant::LongLong:
-            variant = remote_config::ConfigKeyValueVariant { key, static_cast<int64_t>(value.toLongLong()) };
+            defaults << remote_config::ConfigKeyValueVariant { key, static_cast<int64_t>(value.toLongLong()) };
             break;
         case QVariant::Double:
-            variant = remote_config::ConfigKeyValueVariant { key, value.toDouble() };
+            defaults << remote_config::ConfigKeyValueVariant { key, value.toDouble() };
             break;
         case QVariant::String:
             stringsData << value.toString().toUtf8();
-            variant = remote_config::ConfigKeyValueVariant { key, stringsData.last().constData() };
+            defaults << remote_config::ConfigKeyValueVariant { key, stringsData.last().constData() };
             break;
         default:
             break;
         }
-        defaults << variant;
     }
 
 #if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -1,5 +1,7 @@
 #include "qtfirebaseremoteconfig.h"
 
+#include <memory>
+
 namespace remote_config = ::firebase::remote_config;
 
 QtFirebaseRemoteConfig *QtFirebaseRemoteConfig::self = nullptr;
@@ -45,7 +47,6 @@ QtFirebaseRemoteConfig::~QtFirebaseRemoteConfig() {
         remote_config::Terminate();
 #endif
 }
-
 
 bool QtFirebaseRemoteConfig::checkInstance(const char *function)
 {

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -51,6 +51,22 @@ QtFirebaseRemoteConfig::~QtFirebaseRemoteConfig()
         self = nullptr;
 }
 
+void QtFirebaseRemoteConfig::setParameters(const QVariantMap &parameters)
+{
+    if (_parameters == parameters)
+        return;
+    _parameters = parameters;
+    emit parametersChanged();
+}
+
+void QtFirebaseRemoteConfig::setCacheExpirationTime(quint64 ms)
+{
+    if (_cacheExpirationTime == ms)
+        return;
+    _cacheExpirationTime = ms;
+    emit cacheExpirationTimeChanged();
+}
+
 void QtFirebaseRemoteConfig::addParameterInternal(const QString &name, const QVariant &defaultValue)
 {
     _parameters[name] = defaultValue;
@@ -80,11 +96,6 @@ QVariant QtFirebaseRemoteConfig::getParameterValue(const QString &name) const
     return _parameters[name];
 }
 
-bool QtFirebaseRemoteConfig::ready()
-{
-    return _ready;
-}
-
 void QtFirebaseRemoteConfig::setReady(bool ready)
 {
     qDebug() << this << "::setReady before:" << _ready << "now:" << ready;
@@ -92,28 +103,6 @@ void QtFirebaseRemoteConfig::setReady(bool ready)
         _ready = ready;
         emit readyChanged();
     }
-}
-
-QVariantMap QtFirebaseRemoteConfig::parameters() const
-{
-    return _parameters;
-}
-
-void QtFirebaseRemoteConfig::setParameters(const QVariantMap &map)
-{
-    _parameters = map;
-    emit parametersChanged();
-}
-
-quint64 QtFirebaseRemoteConfig::cacheExpirationTime() const
-{
-    return _cacheExpirationTime;
-}
-
-void QtFirebaseRemoteConfig::setCacheExpirationTime(quint64 timeMs)
-{
-    _cacheExpirationTime = timeMs;
-    emit cacheExpirationTimeChanged();
 }
 
 void QtFirebaseRemoteConfig::addParameter(const QString &name, long long defaultValue)

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -31,21 +31,12 @@ QtFirebaseRemoteConfig::QtFirebaseRemoteConfig(QObject *parent)
         return;
     self = this;
 
-    #if defined(Q_OS_ANDROID)
-    if (GooglePlayServices::available()) {
-        qDebug() << this << " Google Play Services is available, now init remote_config" ;
-
-        //Call init outside of constructor, otherwise signal readyChanged not emited
-        QTimer::singleShot(500, this, SLOT(delayedInit()));
-        connect(qFirebase,&QtFirebase::futureEvent, this, &QtFirebaseRemoteConfig::onFutureEvent);
-    } else {
-        qDebug() << this << " Google Play Services is NOT available, CANNOT use remote_config" ;
-    }
-    #else
-    //Call init outside of constructor, otherwise signal readyChanged not emited
-    QTimer::singleShot(500, this, SLOT(delayedInit()));
-    connect(qFirebase,&QtFirebase::futureEvent, this, &QtFirebaseRemoteConfig::onFutureEvent);
-    #endif
+#ifdef Q_OS_ANDROID
+    if (!GooglePlayServices::available())
+        return;
+#endif
+    connect(qFirebase, &QtFirebase::futureEvent, this, &QtFirebaseRemoteConfig::onFutureEvent);
+    QTimer::singleShot(500, this, &QtFirebaseRemoteConfig::delayedInit);
 }
 
 QtFirebaseRemoteConfig::~QtFirebaseRemoteConfig()

--- a/src/qtfirebaseremoteconfig.cpp
+++ b/src/qtfirebaseremoteconfig.cpp
@@ -28,7 +28,7 @@ QtFirebaseRemoteConfig::QtFirebaseRemoteConfig(QObject *parent)
         return;
 #endif
     connect(qFirebase, &QtFirebase::futureEvent, this, &QtFirebaseRemoteConfig::onFutureEvent);
-    QTimer::singleShot(500, this, [ this ] {
+    QTimer::singleShot(0, this, [ this ] {
         if (qFirebase->ready()) {
             init();
             return;

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -68,11 +68,11 @@ private slots:
     void init();
     void onFutureEvent(const QString &eventId, firebase::FutureBase);
 #if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
-    void onFutureEventInit(const firebase::FutureBase &);
-    void onFutureEventDefaults(const firebase::FutureBase &);
-    void onFutureEventActivate(const firebase::FutureBase &);
+    void onFutureEventInit();
+    void onFutureEventDefaults();
+    void onFutureEventActivate();
 #endif
-    void onFutureEventFetch(const firebase::FutureBase &);
+    void onFutureEventFetch();
 private:
     void setReady(bool = true);
     void setFetching(bool = true);

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -19,25 +19,20 @@ class QtFirebaseRemoteConfig : public QObject
     Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
     Q_PROPERTY(QVariantMap parameters READ parameters WRITE setParameters NOTIFY parametersChanged)
     Q_PROPERTY(quint64 cacheExpirationTime READ cacheExpirationTime WRITE setCacheExpirationTime NOTIFY cacheExpirationTimeChanged)
-public:
-    explicit QtFirebaseRemoteConfig(QObject *parent = nullptr);
-    virtual ~QtFirebaseRemoteConfig();
 
-    enum FetchFailure
-    {
+    static QtFirebaseRemoteConfig *self;
+public:
+    static QtFirebaseRemoteConfig *instance(QObject *parent = nullptr);
+
+    enum FetchFailure {
         FetchFailureReasonInvalid = firebase::remote_config::kFetchFailureReasonInvalid,
         FetchFailureReasonThrottled = firebase::remote_config::kFetchFailureReasonThrottled,
         FetchFailureReasonError = firebase::remote_config::kFetchFailureReasonError,
     };
     Q_ENUM(FetchFailure)
 
-    static QtFirebaseRemoteConfig *instance() {
-        if(self == nullptr) {
-            self = new QtFirebaseRemoteConfig(nullptr);
-            qDebug() << self << "::instance" << "singleton";
-        }
-        return self;
-    }
+    explicit QtFirebaseRemoteConfig(QObject *parent = nullptr);
+    virtual ~QtFirebaseRemoteConfig();
 
     bool checkInstance(const char *function);
     bool ready();
@@ -82,8 +77,6 @@ private:
     void setReady(bool ready);
     void fetch(quint64 cacheExpirationInSeconds);
 
-    static QtFirebaseRemoteConfig *self;
-
     QString __QTFIREBASE_ID;
 
     bool _ready;
@@ -99,5 +92,5 @@ private:
     const char *__appId;
 };
 
-#endif //QTFIREBASE_BUILD_REMOTE_CONFIG
+#endif // QTFIREBASE_BUILD_REMOTE_CONFIG
 #endif // QTFIREBASE_REMOTE_CONFIG_H

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -34,13 +34,12 @@ public:
     explicit QtFirebaseRemoteConfig(QObject *parent = nullptr);
     virtual ~QtFirebaseRemoteConfig();
 
-    bool ready();
+    bool ready() const { return _ready; }
 
-    QVariantMap parameters() const;
-    void setParameters(const QVariantMap& map);
-
-    quint64 cacheExpirationTime() const;
-    void setCacheExpirationTime(quint64 timeMs);
+    QVariantMap parameters() const { return _parameters; }
+    quint64 cacheExpirationTime() const { return _cacheExpirationTime; }
+    void setParameters(const QVariantMap &);
+    void setCacheExpirationTime(quint64 ms);
 
 public slots:
     void addParameter(const QString &name, long long defaultValue);

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -5,10 +5,10 @@
 
 #include "src/qtfirebase.h"
 
-#if defined(qFirebaseRemoteConfig)
+#ifdef qFirebaseRemoteConfig
 #undef qFirebaseRemoteConfig
 #endif
-#define qFirebaseRemoteConfig (static_cast<QtFirebaseRemoteConfig *>(QtFirebaseRemoteConfig::instance()))
+#define qFirebaseRemoteConfig (QtFirebaseRemoteConfig::instance())
 
 #include "firebase/remote_config.h"
 

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -50,6 +50,9 @@ public slots:
     void fetch() { fetch(_cacheExpirationTime / 1000); }
     void fetchNow() { fetch(0); }
 signals:
+    void googlePlayServicesError();
+    void futuresError(int code, QString message);
+
     void error(int code, QString message);
 
     void readyChanged();
@@ -59,18 +62,18 @@ signals:
 private slots:
     void init();
     void onFutureEvent(const QString &eventId, firebase::FutureBase);
-
+#if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
     void onFutureEventInit(const firebase::FutureBase &);
+#endif
     void onFutureEventFetch(const firebase::FutureBase &);
 private:
-    void setReady(bool);
+    void setReady(bool = true);
     void addParameterInternal(const QString &name, const QVariant &defaultValue) { _parameters[name] = defaultValue; }
     void fetch(quint64 cacheExpirationInSeconds);
 
 private:
     const QString __QTFIREBASE_ID;
     firebase::ModuleInitializer _initializer;
-    bool _initializing = false;
     bool _ready = false;
     quint64 _cacheExpirationTime = firebase::remote_config::kDefaultCacheExpiration * 1000;
 

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -64,14 +64,14 @@ signals:
     void cacheExpirationTimeChanged();
 
 private slots:
-    void addParameterInternal(const QString &name, const QVariant &defaultValue);
     void init();
+    void addParameterInternal(const QString &name, const QVariant &defaultValue);
     void onFutureEvent(QString eventId, firebase::FutureBase future);
-    void onFutureEventInit(firebase::FutureBase& future);
+    void onFutureEventInit(const firebase::FutureBase& future);
     void onFutureEventFetch(firebase::FutureBase& future);
 
 private:
-    void setReady(bool ready);
+    void setReady(bool);
     void fetch(quint64 cacheExpirationInSeconds);
 
     QString __QTFIREBASE_ID;

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -19,7 +19,6 @@ class QtFirebaseRemoteConfig : public QObject
     Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
     Q_PROPERTY(QVariantMap parameters READ parameters WRITE setParameters NOTIFY parametersChanged)
     Q_PROPERTY(quint64 cacheExpirationTime READ cacheExpirationTime WRITE setCacheExpirationTime NOTIFY cacheExpirationTimeChanged)
-
     static QtFirebaseRemoteConfig *self;
 public:
     static QtFirebaseRemoteConfig *instance(QObject *parent = nullptr);
@@ -41,39 +40,34 @@ public:
     void setParameters(const QVariantMap &);
     void setCacheExpirationTime(quint64 ms);
 
-public slots:
-    void addParameter(const QString &name, long long defaultValue);
-    void addParameter(const QString &name, double defaultValue);
-    void addParameter(const QString &name, const QString& defaultValue);
-    void addParameter(const QString &name, bool defaultValue);
-    QVariant getParameterValue(const QString &name) const;
+    Q_INVOKABLE QVariant getParameterValue(const QString &name) const { return _parameters[name]; }
 
-    //If the data in the cache was fetched no longer than cacheExpirationTime ago,
-    //this method will return the cached data. If not, a fetch from the
-    //Remote Config Server will be attempted.
-    //cacheExpirationTime in QtFirebase should be set in milliseconds
-    //See for details
-    //https://firebase.google.com/docs/reference/android/com/google/firebase/remoteconfig/FirebaseRemoteConfig#fetch()
-    void fetch();
-    void fetchNow();//calls fetch with cacheExpirationTime = 0
+public slots:
+    void addParameter(const QString &name, bool defaultValue) { addParameterInternal(name, defaultValue); }
+    void addParameter(const QString &name, long long defaultValue) { addParameterInternal(name, defaultValue); }
+    void addParameter(const QString &name, double defaultValue) { addParameterInternal(name, defaultValue); }
+    void addParameter(const QString &name, const QString &defaultValue) { addParameterInternal(name, defaultValue); }
+
+    void fetch() { fetch(_cacheExpirationTime / 1000); }
+    void fetchNow() { fetch(0); }
 
 signals:
     void readyChanged();
-    void error(int code, QString message);
     void parametersChanged();
     void cacheExpirationTimeChanged();
 
+    void error(int code, QString message);
 private slots:
     void init();
-    void addParameterInternal(const QString &name, const QVariant &defaultValue);
     void onFutureEvent(QString eventId, firebase::FutureBase future);
     void onFutureEventInit(const firebase::FutureBase& future);
     void onFutureEventFetch(firebase::FutureBase& future);
 
 private:
     void setReady(bool);
+    void addParameterInternal(const QString &name, const QVariant &defaultValue) { _parameters[name] = defaultValue; }
     void fetch(quint64 cacheExpirationInSeconds);
-
+private:
     QString __QTFIREBASE_ID;
 
     bool _ready;

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -5,27 +5,23 @@
 
 #include "src/qtfirebase.h"
 
+#include <firebase/remote_config.h>
+
 #ifdef qFirebaseRemoteConfig
 #undef qFirebaseRemoteConfig
 #endif
 #define qFirebaseRemoteConfig (QtFirebaseRemoteConfig::instance())
 
-#include "firebase/remote_config.h"
-
-#include <memory> //For std::unique_ptr
-#include <QDebug>
-#include <QObject>
-
 class QtFirebaseRemoteConfig : public QObject
 {
     Q_OBJECT
+    Q_DISABLE_COPY(QtFirebaseRemoteConfig)
     Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
     Q_PROPERTY(QVariantMap parameters READ parameters WRITE setParameters NOTIFY parametersChanged)
     Q_PROPERTY(quint64 cacheExpirationTime READ cacheExpirationTime WRITE setCacheExpirationTime NOTIFY cacheExpirationTimeChanged)
-
 public:
     explicit QtFirebaseRemoteConfig(QObject *parent = nullptr);
-    ~QtFirebaseRemoteConfig();
+    virtual ~QtFirebaseRemoteConfig();
 
     enum FetchFailure
     {
@@ -87,7 +83,6 @@ private:
     void fetch(quint64 cacheExpirationInSeconds);
 
     static QtFirebaseRemoteConfig *self;
-    Q_DISABLE_COPY(QtFirebaseRemoteConfig)
 
     QString __QTFIREBASE_ID;
 

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -41,7 +41,6 @@ public:
     void setCacheExpirationTime(quint64 ms);
 
     Q_INVOKABLE QVariant getParameterValue(const QString &name) const { return _parameters[name]; }
-
 public slots:
     void addParameter(const QString &name, bool defaultValue) { addParameterInternal(name, defaultValue); }
     void addParameter(const QString &name, long long defaultValue) { addParameterInternal(name, defaultValue); }
@@ -50,37 +49,33 @@ public slots:
 
     void fetch() { fetch(_cacheExpirationTime / 1000); }
     void fetchNow() { fetch(0); }
-
 signals:
+    void error(int code, QString message);
+
     void readyChanged();
     void parametersChanged();
     void cacheExpirationTimeChanged();
 
-    void error(int code, QString message);
 private slots:
     void init();
-    void onFutureEvent(QString eventId, firebase::FutureBase future);
-    void onFutureEventInit(const firebase::FutureBase& future);
-    void onFutureEventFetch(firebase::FutureBase& future);
+    void onFutureEvent(const QString &eventId, firebase::FutureBase);
 
+    void onFutureEventInit(const firebase::FutureBase &);
+    void onFutureEventFetch(const firebase::FutureBase &);
 private:
     void setReady(bool);
     void addParameterInternal(const QString &name, const QVariant &defaultValue) { _parameters[name] = defaultValue; }
     void fetch(quint64 cacheExpirationInSeconds);
+
 private:
-    QString __QTFIREBASE_ID;
+    const QString __QTFIREBASE_ID;
+    firebase::ModuleInitializer _initializer;
+    bool _initializing = false;
+    bool _ready = false;
+    quint64 _cacheExpirationTime = firebase::remote_config::kDefaultCacheExpiration * 1000;
 
-    bool _ready;
-    bool _initializing;
     QVariantMap _parameters;
-    quint64 _cacheExpirationTime;
-    ::firebase::ModuleInitializer _initializer;
-
-    QString _appId;
-    QByteArray __appIdByteArray;
-
     QByteArrayList __defaultsByteArrayList;
-    const char *__appId;
 };
 
 #endif // QTFIREBASE_BUILD_REMOTE_CONFIG

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -44,6 +44,7 @@ public:
     void setParameters(const QVariantMap &);
 
     Q_INVOKABLE QVariant getParameterValue(const QString &name) const { return _parameters[name]; }
+
 public slots:
     void addParameter(const QString &name, bool defaultValue) { addParameterInternal(name, defaultValue); }
     void addParameter(const QString &name, long long defaultValue) { addParameterInternal(name, defaultValue); }
@@ -59,10 +60,10 @@ signals:
     void cacheExpirationTimeChanged();
     void parametersChanged();
 
-    void googlePlayServicesError();
-    void futuresError(int code, QString message);
+    void googlePlayServicesError(); ///< For Firebase CPP SDK < 8.0.0 only
 
-    void error(int code, QString message);
+    void futuresError(int code, QString message); ///< System error.
+    void error(int code, QString message); ///< Error of last fetch.
 
 private slots:
     void init();

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -89,6 +89,7 @@ private:
 
 #if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
     quint64 _cacheExpirationInSeconds = 0;
+    firebase::remote_config::RemoteConfig *_rc = nullptr;
 #endif
 };
 

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -33,6 +33,8 @@ public:
         return self;
     }
 
+    static bool checkInstance(const char *function = nullptr) { Q_UNUSED(function) return self; }
+
     enum FetchFailure {
         FetchFailureReasonInvalid = firebase::remote_config::kFetchFailureReasonInvalid,
         FetchFailureReasonThrottled = firebase::remote_config::kFetchFailureReasonThrottled,

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -75,9 +75,7 @@ private:
     const QString __QTFIREBASE_ID;
     bool _ready = false;
     quint64 _cacheExpirationTime = firebase::remote_config::kDefaultCacheExpiration * 1000;
-
     QVariantMap _parameters;
-    QByteArrayList __defaultsByteArrayList;
 };
 
 #endif // QTFIREBASE_BUILD_REMOTE_CONFIG

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -34,7 +34,6 @@ public:
     explicit QtFirebaseRemoteConfig(QObject *parent = nullptr);
     virtual ~QtFirebaseRemoteConfig();
 
-    bool checkInstance(const char *function);
     bool ready();
 
     QVariantMap parameters() const;

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -65,7 +65,6 @@ signals:
 
 private slots:
     void addParameterInternal(const QString &name, const QVariant &defaultValue);
-    void delayedInit();
     void init();
     void onFutureEvent(QString eventId, firebase::FutureBase future);
     void onFutureEventInit(firebase::FutureBase& future);

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -69,6 +69,7 @@ private slots:
     void onFutureEvent(const QString &eventId, firebase::FutureBase);
 #if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
     void onFutureEventInit(const firebase::FutureBase &);
+    void onFutureEventDefaults(const firebase::FutureBase &);
 #endif
     void onFutureEventFetch(const firebase::FutureBase &);
 private:
@@ -85,6 +86,10 @@ private:
     bool _fetching = false;
     quint64 _cacheExpirationTime = firebase::remote_config::kDefaultCacheExpiration * 1000;
     QVariantMap _parameters;
+
+#if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
+    quint64 _cacheExpirationInSeconds = 0;
+#endif
 };
 
 #endif // QTFIREBASE_BUILD_REMOTE_CONFIG

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -73,7 +73,6 @@ private:
 
 private:
     const QString __QTFIREBASE_ID;
-    firebase::ModuleInitializer _initializer;
     bool _ready = false;
     quint64 _cacheExpirationTime = firebase::remote_config::kDefaultCacheExpiration * 1000;
 

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -7,6 +7,10 @@
 
 #include <firebase/remote_config.h>
 
+#include <QObject>
+#include <QVariant>
+#include <QVariantMap>
+
 #ifdef qFirebaseRemoteConfig
 #undef qFirebaseRemoteConfig
 #endif
@@ -23,7 +27,11 @@ class QtFirebaseRemoteConfig : public QObject
 
     static QtFirebaseRemoteConfig *self;
 public:
-    static QtFirebaseRemoteConfig *instance(QObject *parent = nullptr);
+    static QtFirebaseRemoteConfig *instance(QObject *parent = nullptr) {
+        if (!self)
+            self = new QtFirebaseRemoteConfig(parent);
+        return self;
+    }
 
     enum FetchFailure {
         FetchFailureReasonInvalid = firebase::remote_config::kFetchFailureReasonInvalid,

--- a/src/qtfirebaseremoteconfig.h
+++ b/src/qtfirebaseremoteconfig.h
@@ -70,6 +70,7 @@ private slots:
 #if QTFIREBASE_FIREBASE_VERSION >= QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
     void onFutureEventInit(const firebase::FutureBase &);
     void onFutureEventDefaults(const firebase::FutureBase &);
+    void onFutureEventActivate(const firebase::FutureBase &);
 #endif
     void onFutureEventFetch(const firebase::FutureBase &);
 private:
@@ -79,6 +80,7 @@ private:
     void addParameterInternal(const QString &name, const QVariant &defaultValue) { _parameters[name] = defaultValue; }
     void fetch(quint64 cacheExpirationInSeconds);
 
+    void updateParameters();
 private:
     const QString __QTFIREBASE_ID;
 

--- a/stub/src/qtfirebaseremoteconfig.h
+++ b/stub/src/qtfirebaseremoteconfig.h
@@ -33,6 +33,8 @@ public:
         return self;
     }
 
+    static bool checkInstance(const char *function = nullptr) { Q_UNUSED(function) return self; }
+
     enum FetchFailure {
         FetchFailureReasonInvalid = firebase::remote_config::kFetchFailureReasonInvalid,
         FetchFailureReasonThrottled = firebase::remote_config::kFetchFailureReasonThrottled,

--- a/stub/src/qtfirebaseremoteconfig.h
+++ b/stub/src/qtfirebaseremoteconfig.h
@@ -1,74 +1,78 @@
 #ifndef QTFIREBASE_REMOTE_CONFIG_H
 #define QTFIREBASE_REMOTE_CONFIG_H
 
-#include <QObject>
-
 #ifdef QTFIREBASE_BUILD_REMOTE_CONFIG
 
-#include "qtfirebase.h"
+#include "src/qtfirebase.h"
+
+#include <firebase/remote_config.h>
+
+#include <QObject>
+#include <QVariant>
 #include <QVariantMap>
 
-#if defined(qFirebaseRemoteConfig)
+#ifdef qFirebaseRemoteConfig
 #undef qFirebaseRemoteConfig
 #endif
-#define qFirebaseRemoteConfig (static_cast<QtFirebaseRemoteConfig *>(QtFirebaseRemoteConfig::instance()))
+#define qFirebaseRemoteConfig (QtFirebaseRemoteConfig::instance())
 
 class QtFirebaseRemoteConfig : public QObject
 {
     Q_OBJECT
+    Q_DISABLE_COPY(QtFirebaseRemoteConfig)
     Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
-    Q_PROPERTY(QVariantMap parameters READ parameters WRITE setParameters NOTIFY parametersChanged)
+    Q_PROPERTY(bool fetching READ fetching NOTIFY fetchingChanged)
     Q_PROPERTY(quint64 cacheExpirationTime READ cacheExpirationTime WRITE setCacheExpirationTime NOTIFY cacheExpirationTimeChanged)
+    Q_PROPERTY(QVariantMap parameters READ parameters WRITE setParameters NOTIFY parametersChanged)
 
+    inline static QtFirebaseRemoteConfig *self = nullptr;
 public:
-    enum FetchFailure
-    {
-        FetchFailureReasonInvalid,
-        FetchFailureReasonThrottled,
-        FetchFailureReasonError,
+    static QtFirebaseRemoteConfig *instance(QObject *parent = nullptr) {
+        if (!self)
+            self = new QtFirebaseRemoteConfig(parent);
+        return self;
+    }
+
+    enum FetchFailure {
+        FetchFailureReasonInvalid = firebase::remote_config::kFetchFailureReasonInvalid,
+        FetchFailureReasonThrottled = firebase::remote_config::kFetchFailureReasonThrottled,
+        FetchFailureReasonError = firebase::remote_config::kFetchFailureReasonError,
     };
     Q_ENUM(FetchFailure)
 
-    explicit QtFirebaseRemoteConfig(QObject *parent = nullptr){ Q_UNUSED(parent) }
+    explicit QtFirebaseRemoteConfig(QObject *parent = nullptr) : QObject(parent) { }
+    virtual ~QtFirebaseRemoteConfig() { }
 
-    ~QtFirebaseRemoteConfig() {}
+    bool ready() const { return false; }
+    bool fetching() const { return false; }
+    quint64 cacheExpirationTime() const { return 0; }
+    QVariantMap parameters() const { return QVariantMap(); }
 
-    static QtFirebaseRemoteConfig *instance() {
-            if(self == nullptr) {
-                self = new QtFirebaseRemoteConfig(nullptr);
-            }
-            return self;
-        }
+    void setCacheExpirationTime(quint64) { }
+    void setParameters(const QVariantMap &) { }
 
-    bool checkInstance(const char *function);
-    bool ready(){return false;}
-
-    QVariantMap parameters() const{return QVariantMap();}
-    void setParameters(const QVariantMap& map){ Q_UNUSED(map) }
-
-    quint64 cacheExpirationTime() const{return 0;}
-    void setCacheExpirationTime(quint64 timeMs){ Q_UNUSED(timeMs) }
+    Q_INVOKABLE QVariant getParameterValue(const QString &) const { return QVariant(); }
 
 public slots:
-    void addParameter(const QString &name, long long defaultValue){ Q_UNUSED(name) Q_UNUSED(defaultValue) }
-    void addParameter(const QString &name, double defaultValue){ Q_UNUSED(name) Q_UNUSED(defaultValue) }
-    void addParameter(const QString &name, const QString& defaultValue){ Q_UNUSED(name) Q_UNUSED(defaultValue) }
-    void addParameter(const QString &name, bool defaultValue){ Q_UNUSED(name) Q_UNUSED(defaultValue) }
-    QVariant getParameterValue(const QString) const{ return QString(); }
+    void addParameter(const QString &, bool) { }
+    void addParameter(const QString &, long long) { }
+    void addParameter(const QString &, double) { }
+    void addParameter(const QString &, const QString &) { }
 
-    void fetch(){}
-    void fetchNow(){}
-
+    void fetchNow() { }
+    void fetch() { }
 signals:
-    void readyChanged();
-    void error(int code, QString message);
-    void parametersChanged();
-    void cacheExpirationTimeChanged();
 
-private:
-    static QtFirebaseRemoteConfig *self;
-    Q_DISABLE_COPY(QtFirebaseRemoteConfig)
+    void readyChanged();
+    void fetchingChanged();
+    void cacheExpirationTimeChanged();
+    void parametersChanged();
+
+    void googlePlayServicesError(); ///< For Firebase CPP SDK < 8.0.0 only
+
+    void futuresError(int code, QString message); ///< System error.
+    void error(int code, QString message); ///< Error of last fetch.
 };
 
-#endif //QTFIREBASE_BUILD_REMOTE_CONFIG
+#endif // QTFIREBASE_BUILD_REMOTE_CONFIG
 #endif // QTFIREBASE_REMOTE_CONFIG_H


### PR DESCRIPTION
Hello!

1. In case of Firebase CPP SDK >= 8.0.0, there was no control of futures returned from SDK code. So the correctness was not guaranteed.
2. In case of Firebase CPP SDK >= 8.0.0, no need to give up if Google Play Services is not available. They could be updating, for example, SDK defines a set of reasons and supports its API anyway. So let it decide.
3. Initial 500 ms delay has been removed from the initialization workflow: ```QTimer::singleShot(500 -> 0, ...)```.
4. Added new property ```fetching```.
5. Added new signals ```googlePlayServicesError``` and ```futuresError```.
6. Pooling future's status on timer is not an elegant and efficient solution, I used callbacks.
7. Support of Firebase CPP SDK < 8.0.0 has been kept.
8. Backward compatibility of QtFirebase API has been kept.