### PR TITLE
Analytics: Refactoring

### DIFF
--- a/src/qtfirebase.cpp
+++ b/src/qtfirebase.cpp
@@ -80,11 +80,6 @@ void QtFirebase::waitForFutureCompletion(firebase::FutureBase future)
     }
 }
 
-firebase::App* QtFirebase::firebaseApp() const
-{
-    return _firebaseApp;
-}
-
 void QtFirebase::addFuture(const QString &eventId, const firebase::FutureBase &future)
 {
     qDebug() << self << "::addFuture" << "adding" << eventId;

--- a/src/qtfirebase.h
+++ b/src/qtfirebase.h
@@ -50,7 +50,7 @@ public:
     static void waitForFutureCompletion(firebase::FutureBase future);
     bool checkInstance(const char *function);
 
-    firebase::App* firebaseApp() const;
+    firebase::App *firebaseApp() const { return _firebaseApp; }
 
     // TODO make protected and have friend classes?
     void addFuture(const QString &eventId, const firebase::FutureBase &future);

--- a/src/qtfirebaseanalytics.cpp
+++ b/src/qtfirebaseanalytics.cpp
@@ -300,6 +300,19 @@ void QtFirebaseAnalytics::logEvent(const QString &name, const QString &param, in
     analytics::LogEvent(nameFixed.toUtf8().constData(), paramFixed.toUtf8().constData(), value);
 }
 
+void QtFirebaseAnalytics::logEvent(const QString &name, const QString &param, long long value)
+{
+    QTFIREBASE_ANALYTICS_CHECK_READY("::logEvent")
+    qDebug() << this << "::logEvent" << name << "long long param" << param << ":" << value;
+    QString nameFixed;
+    QString paramFixed;
+    if (!checkEventName(nameFixed, name))
+        return;
+    if (!checkParamName(paramFixed, param))
+        return;
+    analytics::LogEvent(nameFixed.toUtf8().constData(), paramFixed.toUtf8().constData(), static_cast<int64_t>(value));
+}
+
 void QtFirebaseAnalytics::logEvent(const QString &name, const QString &param, double value)
 {
     QTFIREBASE_ANALYTICS_CHECK_READY("::logEvent")
@@ -355,6 +368,12 @@ void QtFirebaseAnalytics::logEvent(const QString &name, const QVariantMap &bundl
             const int intVal = value.toInt();
             parameters << analytics::Parameter(keyStr, intVal);
             qDebug() << this << "::logEvent bundle param" << keyStr << ":" << intVal;
+            break;
+        }
+        case QVariant::LongLong: {
+            const int longLongVal = value.toLongLong();
+            parameters << analytics::Parameter(keyStr, static_cast<int64_t>(longLongVal));
+            qDebug() << this << "::logEvent bundle param" << keyStr << ":" << longLongVal;
             break;
         }
         case QVariant::Double: {

--- a/src/qtfirebaseanalytics.cpp
+++ b/src/qtfirebaseanalytics.cpp
@@ -396,21 +396,21 @@ void QtFirebaseAnalytics::logEvent(const QString &event, const QVariantMap &bund
             const int intVal = value.toInt();
 
             parameters << analytics::Parameter(keyStr, intVal);
-            qDebug() << this << "::logEvent bundle param" << keyStr << ":" << intVal;
+            qDebug() << this << "::logEvent bundle int param" << keyStr << ":" << intVal;
             break;
         }
         case QVariant::LongLong: {
             const int longLongVal = value.toLongLong();
 
             parameters << analytics::Parameter(keyStr, static_cast<int64_t>(longLongVal));
-            qDebug() << this << "::logEvent bundle param" << keyStr << ":" << longLongVal;
+            qDebug() << this << "::logEvent bundle long long param" << keyStr << ":" << longLongVal;
             break;
         }
         case QVariant::Double: {
             const double doubleVal = value.toDouble();
 
             parameters << analytics::Parameter(keyStr, doubleVal);
-            qDebug() << this << "::logEvent bundle param" << keyStr << ":" << doubleVal;
+            qDebug() << this << "::logEvent bundle double param" << keyStr << ":" << doubleVal;
             break;
         }
         case QVariant::String: {
@@ -424,7 +424,7 @@ void QtFirebaseAnalytics::logEvent(const QString &event, const QVariantMap &bund
             }
 
             parameters << analytics::Parameter(keyStr, valueStr);
-            qDebug() << this << "::logEvent bundle param" << keyStr << ":" << valueStr;
+            qDebug() << this << "::logEvent bundle string param" << keyStr << ":" << valueStr;
             break;
         }
         default:

--- a/src/qtfirebaseanalytics.cpp
+++ b/src/qtfirebaseanalytics.cpp
@@ -228,7 +228,12 @@ void QtFirebaseAnalytics::setCurrentScreen(const QString &screenName, const QStr
 bool QtFirebaseAnalytics::checkEventName(QString &fixed, const QString &name) const
 {
     if (name.isEmpty()) {
-        qWarning().noquote() << this << "::logEvent event is empty";
+        qWarning().noquote() << this << "::logEvent event name is empty";
+        return false;
+    }
+
+    if (name.startsWith(QStringLiteral("firebase_"))) {
+        qWarning().noquote() << this << "::logEvent event name is reserved";
         return false;
     }
 
@@ -252,8 +257,20 @@ bool QtFirebaseAnalytics::checkEventName(QString &fixed, const QString &name) co
 
 bool QtFirebaseAnalytics::checkParamName(QString &fixed, const QString &name) const
 {
-    if (name.isEmpty())
+    if (name.isEmpty()) {
+        qWarning().noquote() << this << "::logEvent param name is empty";
         return false;
+    }
+
+    static QStringList reserved {
+        QStringLiteral("firebase_"),
+        QStringLiteral("google_"),
+        QStringLiteral("ga_"),
+    };
+    if (std::any_of(reserved.cbegin(), reserved.cend(), [ &name ](const QString &prefix) { return name.startsWith(prefix); })) {
+        qWarning().noquote() << this << "::logEvent param name is reserved";
+        return false;
+    }
 
     const auto aName = fixStringLength(name, PARAM_NAME_MAX_LEN, "::logEvent", "param name");
     const auto aNameUtf8 = aName.toUtf8();

--- a/src/qtfirebaseanalytics.cpp
+++ b/src/qtfirebaseanalytics.cpp
@@ -1,338 +1,295 @@
 #include "qtfirebaseanalytics.h"
 
-#include <QGuiApplication>
+#include <firebase/analytics.h>
 
-namespace analytics = ::firebase::analytics;
+#include <QVector>
+#include <QDebug>
 
-QtFirebaseAnalytics *QtFirebaseAnalytics::self = nullptr;
+namespace analytics = firebase::analytics;
 
-QtFirebaseAnalytics::QtFirebaseAnalytics(QObject* parent)
+QtFirebaseAnalytics *QtFirebaseAnalytics::self { nullptr };
+
+QtFirebaseAnalytics::QtFirebaseAnalytics(QObject *parent)
     : QObject(parent)
-    , _ready(false)
-    , _initializing(false)
-    , _enabled(false)
-    , _minimumSessionDuration(0) // Depricated
-    , _sessionTimeout(1800000)
-    , _userId()
-    , _userProperties()
 {
-    if(!self) {
-        self = this;
-        qDebug() << self << "::QtFirebaseAnalytics" << "singleton";
-    }
+    // deny multiple instances
+    Q_ASSERT(!self);
+    if (self)
+        return;
+    self = this;
 
-    if(qFirebase->ready())
-        init();
-    else {
-        connect(qFirebase,&QtFirebase::readyChanged, this, &QtFirebaseAnalytics::init);
+    QTimer::singleShot(0, this, [ this ] {
+        if (qFirebase->ready()) {
+            init();
+            return;
+        }
+        connect(qFirebase, &QtFirebase::readyChanged, this, &QtFirebaseAnalytics::init);
         qFirebase->requestInit();
-    }
+    });
 }
 
 QtFirebaseAnalytics::~QtFirebaseAnalytics()
 {
-    if(_ready) {
-        qDebug() << self << "::~QtFirebaseAnalytics" << "shutting down";
+    if (_ready)
         analytics::Terminate();
-        _ready = false;
+
+    // check this instance is legal
+    if (self == this)
         self = nullptr;
-    }
 }
 
-bool QtFirebaseAnalytics::checkInstance(const char *function)
+void QtFirebaseAnalytics::init()
 {
-    bool b = (QtFirebaseAnalytics::self != nullptr);
-    if (!b)
-        qWarning("QtFirebaseAnalytics::%s: Please instantiate the QtFirebaseAnalytics object first", function);
-    return b;
+    if (!qFirebase->ready() || _ready)
+        return;
+
+    const auto app = qFirebase->firebaseApp();
+
+    analytics::Initialize(*app);
+    analytics::SetSessionTimeoutDuration(_sessionTimeout);
+
+    setReady();
 }
 
-void QtFirebaseAnalytics::setUserProperty(const QString &propertyName, const QString &propertyValue)
+void QtFirebaseAnalytics::setReady(bool ready)
 {
-    if(!_ready) {
-        qDebug() << this << "::setUserProperty native part not ready";
+    if (_ready == ready)
+        return;
+    _ready = ready;
+    emit readyChanged();
+}
+
+void QtFirebaseAnalytics::setEnabled(bool enabled)
+{
+    if (!_ready) {
+        qDebug() << this << "::setEnabled native part not ready";
         return;
     }
 
-    qDebug() << this << "::setUserProperty" << propertyName << ":" << propertyValue;
-    analytics::SetUserProperty(propertyName.toLatin1().constData(), propertyValue.toLatin1().constData());
+    if (_enabled == enabled)
+        return;
+
+    analytics::SetAnalyticsCollectionEnabled(enabled);
+
+    _enabled = enabled;
+    qDebug() << this << "::setEnabled" << enabled;
+    emit enabledChanged();
+}
+
+void QtFirebaseAnalytics::setMinimumSessionDuration(uint minimumSessionDuration)
+{
+    qWarning() << this << "::setMinimumSessionDuration is deprecated and no longer functional";
+    if (!_ready) {
+        qDebug() << this << "::setMinimumSessionDuration native part not ready";
+        return;
+    }
+
+    if (_minimumSessionDuration == minimumSessionDuration)
+        return;
+
+    _minimumSessionDuration = minimumSessionDuration;
+    qDebug() << this << "::setMinimumSessionDuration" << minimumSessionDuration;
+    emit minimumSessionDurationChanged();
+}
+
+void QtFirebaseAnalytics::setSessionTimeout(uint sessionTimeout)
+{
+    if (!_ready) {
+        qDebug() << this << "::setSessionTimeout native part not ready";
+        return;
+    }
+
+    if (_sessionTimeout == sessionTimeout)
+        return;
+
+    analytics::SetSessionTimeoutDuration(_sessionTimeout);
+
+    _sessionTimeout = sessionTimeout;
+    qDebug() << this << "::setSessionTimeout" << sessionTimeout;
+    emit sessionTimeoutChanged();
+}
+
+void QtFirebaseAnalytics::setUserId(const QString &userId)
+{
+    if (!_ready) {
+        qDebug() << this << "::setUserId native part not ready";
+        return;
+    }
+    if (userId.isEmpty())
+        return unsetUserId();
+
+    auto aUserId = userId;
+    if (aUserId.length() > 36) {
+        aUserId = aUserId.left(36);
+        qWarning() << this << "::setUserId" << "ID longer than allowed 36 chars" << "TRUNCATED to" << aUserId;
+    }
+    if (_userId == aUserId)
+        return;
+
+    analytics::SetUserId(_userId.toUtf8().constData());
+
+    _userId = aUserId;
+    qDebug() << this << "::setUserId" << _userId;
+    emit userIdChanged();
+}
+
+void QtFirebaseAnalytics::setUserProperties(const QVariantList &userProperties)
+{
+    if (!_ready) {
+        qDebug() << this << "::setUserProperties native part not ready";
+        return;
+    }
+
+    if (_userProperties == userProperties)
+        return;
+    _userProperties = userProperties;
+
+    if (_userProperties.size() > 25)
+        qWarning() << this << "::setUserProperties size is more than 25";
+
+    uint index = 0;
+    for (auto it = _userProperties.cbegin(); it != _userProperties.cend(); ++it, ++index) {
+        const bool ok = (*it).canConvert<QVariantMap>();
+        if (!ok) {
+            qWarning() << this << "::setUserProperties wrong entry at index" << index;
+            continue;
+        }
+        const auto map = (*it).toMap();
+        if (map.isEmpty())
+            continue;
+        const auto &first = map.first();
+        if (first.canConvert<QString>()) {
+            const auto key = map.firstKey();
+            const auto value = first.toString();
+            setUserProperty(key, value);
+        }
+    }
+    emit userPropertiesChanged();
+}
+
+void QtFirebaseAnalytics::setUserProperty(const QString &name, const QString &value)
+{
+    if (!_ready) {
+        qDebug() << this << "::setUserProperty native part not ready";
+        return;
+    }
+    qDebug() << this << "::setUserProperty" << name << ":" << value;
+    analytics::SetUserProperty(name.toUtf8().constData(), value.toUtf8().constData());
+}
+
+void QtFirebaseAnalytics::unsetUserId()
+{
+    if (!_ready) {
+        qDebug() << this << "::unsetUserId native part not ready";
+        return;
+    }
+
+    if (_userId.isEmpty())
+        return;
+    _userId.clear();
+    analytics::SetUserId(nullptr);
+    emit userIdChanged();
 }
 
 #if QTFIREBASE_FIREBASE_VERSION < QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
 void QtFirebaseAnalytics::setCurrentScreen(const QString &screenName, const QString &screenClass)
 {
-    if(!_ready) {
+    qWarning() << this << "::setCurrentScreen is deprecated";
+    if (!_ready) {
         qDebug() << this << "::setCurrentScreen native part not ready";
         return;
     }
-
-    qDebug() << this << "::setCurrentScreen" << screenName << ":" << screenClass ;
-    analytics::SetCurrentScreen(screenName.toLatin1().constData(), screenClass.toLatin1().constData());
+    qDebug() << this << "::setCurrentScreen" << screenName << ":" << screenClass;
+    analytics::SetCurrentScreen(screenName.toUtf8().constData(), screenClass.toUtf8().constData());
 }
 #endif
 
 void QtFirebaseAnalytics::logEvent(const QString &name)
 {
-    if(!_ready) {
+    if (!_ready) {
         qDebug() << this << "::logEvent native part not ready";
         return;
     }
-
-    qDebug() << this << "::logEvent" << name << "logging (no parameters)";
+    qDebug() << this << "::logEvent" << name << "(no params)";
     analytics::LogEvent(name.toUtf8().constData());
 }
 
-void QtFirebaseAnalytics::logEvent(const QString &name, const QString &parameterName, const QString &parameterValue)
+void QtFirebaseAnalytics::logEvent(const QString &name, const QString &param, int value)
 {
-    if(!_ready) {
+    if (!_ready) {
         qDebug() << this << "::logEvent native part not ready";
         return;
     }
-
-    qDebug() << this << "::logEvent" << name << "logging string parameter" << parameterName << ":" << parameterValue;
-    analytics::LogEvent(name.toUtf8().constData(), parameterName.toUtf8().constData(),parameterValue.toUtf8().constData());
+    qDebug() << this << "::logEvent" << name << "int param" << param << ":" << value;
+    analytics::LogEvent(name.toUtf8().constData(), param.toUtf8().constData(), value);
 }
 
-void QtFirebaseAnalytics::logEvent(const QString &name, const QString &parameterName, const double parameterValue)
+void QtFirebaseAnalytics::logEvent(const QString &name, const QString &param, double value)
 {
-    if(!_ready) {
+    if (!_ready) {
         qDebug() << this << "::logEvent native part not ready";
         return;
     }
-
-    qDebug() << this << "::logEvent" << name << "logging double parameter" << parameterName << ":" << parameterValue;
-    analytics::LogEvent(name.toUtf8().constData(), parameterName.toUtf8().constData(),parameterValue);
+    qDebug() << this << "::logEvent" << name << "double param" << param << ":" << value;
+    analytics::LogEvent(name.toUtf8().constData(), param.toUtf8().constData(), value);
 }
 
-void QtFirebaseAnalytics::logEvent(const QString &name, const QString &parameterName, const int parameterValue)
+void QtFirebaseAnalytics::logEvent(const QString &name, const QString &param, const QString &value)
 {
-    if(!_ready) {
+    if (!_ready) {
         qDebug() << this << "::logEvent native part not ready";
         return;
     }
-
-    qDebug() << this << "::logEvent" << name << "logging int parameter" << parameterName << ":" << parameterValue;
-    analytics::LogEvent(name.toUtf8().constData(), parameterName.toUtf8().constData(),parameterValue);
+    qDebug() << this << "::logEvent" << name << "string param" << param << ":" << value;
+    analytics::LogEvent(name.toUtf8().constData(), param.toUtf8().constData(), value.toUtf8().constData());
 }
 
 void QtFirebaseAnalytics::logEvent(const QString &name, const QVariantMap &bundle)
 {
-    if(!_ready) {
+    if (!_ready) {
         qDebug() << this << "::logEvent native part not ready";
         return;
     }
+    qDebug().noquote() << this << "::logEvent bundle" << name;
 
-    analytics::Parameter *parameters = new analytics::Parameter[bundle.size()];
+    QVector<analytics::Parameter> parameters;
+    parameters.reserve(bundle.size());
 
-    QByteArrayList keys;
-    QByteArrayList strings;
+    QByteArrayList stringsData;
+    QByteArrayList keysData;
+    for (auto it = bundle.cbegin(); it != bundle.cend(); ++it) {
+        keysData << it.key().toUtf8();
 
-    QMapIterator<QString, QVariant> i(bundle);
-    int index = 0;
-    while (i.hasNext()) {
-        i.next();
+        const auto keyStr = keysData.last().constData();
 
-        keys.append(i.key().toUtf8());
-        QString eventKey = i.key();
-        QVariant variant = i.value();
-
-        if(variant.type() == QVariant::Type(QMetaType::Int)) {
-            parameters[index] = analytics::Parameter(keys.at(index).constData(), variant.toInt());
-            qDebug() << this << "::logEvent" << "bundle parameter" << eventKey << ":" << variant.toInt();
-        } else if(variant.type() == QVariant::Type(QMetaType::Double)) {
-            parameters[index] = analytics::Parameter(keys.at(index).constData(),variant.toDouble());
-            qDebug() << this << "::logEvent" << "bundle parameter" << eventKey << ":" << variant.toDouble();
-        } else if(variant.type() == QVariant::Type(QMetaType::QString)) {
-            strings.append(variant.toString().toUtf8());
-            parameters[index] = analytics::Parameter(keys.at(index).constData(), strings.at(strings.size()-1).constData());
-            qDebug() << this << "::logEvent" << "bundle parameter" << eventKey << ":" << strings.at(strings.size()-1);
-        } else {
-            qWarning() << this << "::logEvent" << "bundle parameter" << eventKey << "has unsupported data type. Sending empty strings";
-            parameters[index] = analytics::Parameter("", "");
+        const auto &value = it.value();
+        const auto type = value.type();
+        switch (type) {
+        case QVariant::Int: {
+            const int intVal = value.toInt();
+            parameters << analytics::Parameter(keyStr, intVal);
+            qDebug() << this << "::logEvent bundle param" << keyStr << ":" << intVal;
+            break;
         }
-
-        index++;
-    }
-
-    qDebug() << this << "::logEvent" << "logging" << "bundle" << name;
-    analytics::LogEvent(name.toUtf8().constData(), parameters, static_cast<size_t>(bundle.size()));
-    delete[] parameters;
-    parameters = nullptr;
-}
-
-QVariantList QtFirebaseAnalytics::userProperties() const
-{
-    return _userProperties;
-}
-
-void QtFirebaseAnalytics::setUserProperties(const QVariantList &userProperties)
-{
-    if(!_ready) {
-        qDebug() << this << "::setUserProperties native part not ready";
-        return;
-    }
-
-    if (_userProperties != userProperties) {
-        _userProperties = userProperties;
-
-        if(_userProperties.size() > 25) {
-
+        case QVariant::Double: {
+            const double doubleVal = value.toDouble();
+            parameters << analytics::Parameter(keyStr, doubleVal);
+            qDebug() << this << "::logEvent bundle param" << keyStr << ":" << doubleVal;
+            break;
         }
-
-        unsigned index = 0;
-        for (QVariantList::iterator j = _userProperties.begin(); j != _userProperties.end(); j++)
-        {
-            if((*j).canConvert<QVariantMap>()) {
-
-                QVariantMap map = (*j).toMap();
-
-                if(!map.isEmpty()) {
-                    if(map.first().canConvert<QString>()) {
-                        QString key = map.firstKey();
-                        QString value = map.first().toString();
-                        setUserProperty(key,value);
-                    }
-                }
-
-            } else {
-                qWarning() << this << "::setUserProperties" << "wrong entry in userProperties list at index" << index;
-            }
-            index++;
+        case QVariant::String: {
+            stringsData << value.toString().toUtf8();
+            const auto valueStr = stringsData.last().constData();
+            parameters << analytics::Parameter(keyStr, valueStr);
+            qDebug() << this << "::logEvent bundle param" << keyStr << ":" << valueStr;
+            break;
         }
-        emit userPropertiesChanged();
-    }
-}
-
-QString QtFirebaseAnalytics::userId() const
-{
-    return _userId;
-}
-
-void QtFirebaseAnalytics::setUserId(const QString &userId)
-{
-    if(!_ready) {
-        qDebug() << this << "::setUserId native part not ready";
-        return;
-    }
-
-    QString aUserId = userId;
-    if(aUserId.isEmpty()) {
-        unsetUserId();
-    }
-    if(aUserId.length() > 36) {
-        aUserId = aUserId.left(36);
-        qWarning() << this << "::setUserId" << "ID longer than allowed 36 chars" << "TRUNCATED to" << aUserId;
-    }
-    if(_userId != aUserId) {
-        _userId = aUserId;
-        analytics::SetUserId(_userId.toLatin1().constData());
-        qDebug() << this << "::setUserId sat to" << _userId;
-        emit userIdChanged();
-    }
-}
-
-void QtFirebaseAnalytics::unsetUserId()
-{
-    if(!_ready) {
-        qDebug() << this << "::unsetUserId native part not ready";
-        return;
-    }
-
-    if(!_userId.isEmpty()) {
-        _userId.clear();
-        analytics::SetUserId(nullptr);
-        emit userIdChanged();
-    }
-}
-
-unsigned int QtFirebaseAnalytics::sessionTimeout() const
-{
-    return _sessionTimeout;
-}
-
-void QtFirebaseAnalytics::setSessionTimeout(unsigned int sessionTimeout)
-{
-    if(_sessionTimeout != sessionTimeout) {
-        _sessionTimeout = sessionTimeout;
-        emit sessionTimeoutChanged();
-
-        if(_ready) {
-            analytics::SetSessionTimeoutDuration(_sessionTimeout);
+        default:
+            parameters << analytics::Parameter("", "");
+            qWarning() << this << "::logEvent bundle param" << keyStr << "with unsupported data type";
+            break;
         }
     }
-}
 
-bool QtFirebaseAnalytics::ready()
-{
-    return _ready;
-}
-
-void QtFirebaseAnalytics::setReady(bool ready)
-{
-    if (_ready != ready) {
-        _ready = ready;
-        qDebug() << self << "::setReady" << ready;
-        emit readyChanged();
-    }
-}
-
-bool QtFirebaseAnalytics::enabled()
-{
-    return _enabled;
-}
-
-void QtFirebaseAnalytics::setEnabled(bool enabled)
-{
-    if(!_ready) {
-        qDebug() << this << "::setEnabled native part not ready";
-        return;
-    }
-
-    if (_enabled != enabled) {
-        analytics::SetAnalyticsCollectionEnabled(enabled);
-        _enabled = enabled;
-        qDebug() << self << "::setEnabled" << enabled;
-        emit enabledChanged();
-    }
-}
-
-unsigned int QtFirebaseAnalytics::minimumSessionDuration()
-{
-    return _minimumSessionDuration;
-}
-
-void QtFirebaseAnalytics::setMinimumSessionDuration(unsigned int minimumSessionDuration)
-{
-    qWarning() << this << "::setMinimumSessionDuration is deprecated and no longer functional!";
-
-    if(!_ready) {
-        qDebug() << this << "::setMinimumSessionDuration native part not ready";
-        return;
-    }
-
-    if (_minimumSessionDuration != minimumSessionDuration) {
-        _minimumSessionDuration = minimumSessionDuration;
-        qDebug() << self << "::setMinimumSessionDuration" << minimumSessionDuration;
-        emit minimumSessionDurationChanged();
-    }
-}
-
-void QtFirebaseAnalytics::init()
-{
-    if(!qFirebase->ready()) {
-        qDebug() << self << "::init" << "base not ready";
-        return;
-    }
-
-    if(!_ready && !_initializing) {
-        _initializing = true;
-
-        analytics::Initialize(*qFirebase->firebaseApp());
-        qDebug() << self << "::init" << "native initialized";
-        _initializing = false;
-        setReady(true);
-
-        // Set current session duration timeout if it was set up already
-        analytics::SetSessionTimeoutDuration(_sessionTimeout);
-    }
+    analytics::LogEvent(name.toUtf8().constData(), parameters.constData(), static_cast<size_t>(parameters.length()));
 }

--- a/src/qtfirebaseanalytics.cpp
+++ b/src/qtfirebaseanalytics.cpp
@@ -12,6 +12,7 @@
     }
 
 const int USER_ID_MAX_LEN { 256 };
+const int USER_PROPS_LIST_MAX_LEN { 25 };
 
 namespace analytics = firebase::analytics;
 
@@ -134,8 +135,8 @@ void QtFirebaseAnalytics::setUserProperties(const QVariantList &userProperties)
         return;
     _userProperties = userProperties;
 
-    if (_userProperties.size() > 25)
-        qWarning() << this << "::setUserProperties size is more than 25";
+    if (_userProperties.size() > USER_PROPS_LIST_MAX_LEN)
+        qWarning().noquote() << this << "::setUserProperties list length is more than" << USER_PROPS_LIST_MAX_LEN;
 
     uint index = 0;
     for (auto it = _userProperties.cbegin(); it != _userProperties.cend(); ++it, ++index) {

--- a/src/qtfirebaseanalytics.cpp
+++ b/src/qtfirebaseanalytics.cpp
@@ -400,7 +400,7 @@ void QtFirebaseAnalytics::logEvent(const QString &event, const QVariantMap &bund
             const auto t = QStringLiteral("%1 value").arg(keyFixed).toUtf8();
             const auto aValue = fixStringLength(value.toString(), PARAM_VALUE_MAX_LEN, "::logEvent", t.constData());
 
-            char *valueStr = nullptr;
+            const char *valueStr = nullptr;
             if (!aValue.isEmpty()) {
                 stringsData << aValue.toUtf8();
                 valueStr = stringsData.last().constData();

--- a/src/qtfirebaseanalytics.cpp
+++ b/src/qtfirebaseanalytics.cpp
@@ -24,6 +24,8 @@ QtFirebaseAnalytics::QtFirebaseAnalytics(QObject *parent)
         return;
     self = this;
 
+    connect(this, &QtFirebaseAnalytics::readyChanged, this, &QtFirebaseAnalytics::processCache);
+
     QTimer::singleShot(0, this, [ this ] {
         if (qFirebase->ready()) {
             init();
@@ -54,6 +56,16 @@ void QtFirebaseAnalytics::init()
     analytics::SetSessionTimeoutDuration(_sessionTimeout);
 
     setReady();
+}
+
+void QtFirebaseAnalytics::processCache()
+{
+    if (!_ready)
+        return;
+
+    for (const auto &f : qAsConst(_cache))
+        f();
+    _cache.clear();
 }
 
 void QtFirebaseAnalytics::setReady(bool ready)
@@ -174,41 +186,58 @@ void QtFirebaseAnalytics::setCurrentScreen(const QString &screenName, const QStr
 
 void QtFirebaseAnalytics::logEvent(const QString &event)
 {
+    if (!_ready)
+        _cache << [ this, event ] { logEvent(event); };
     QTFIREBASE_ANALYTICS_CHECK_READY("::logEvent")
+
     qDebug() << this << "::logEvent" << event << "with no params";
     analytics::LogEvent(event.toUtf8().constData());
 }
 
 void QtFirebaseAnalytics::logEvent(const QString &event, const QString &param, int value)
 {
+    if (!_ready)
+        _cache << [ this, event, param, value ] { logEvent(event, param, value); };
     QTFIREBASE_ANALYTICS_CHECK_READY("::logEvent")
+
     qDebug() << this << "::logEvent" << event << "int param" << param << ":" << value;
     analytics::LogEvent(event.toUtf8().constData(), param.toUtf8().constData(), value);
 }
 
 void QtFirebaseAnalytics::logEvent(const QString &event, const QString &param, long long value)
 {
+    if (!_ready)
+        _cache << [ this, event, param, value ] { logEvent(event, param, value); };
     QTFIREBASE_ANALYTICS_CHECK_READY("::logEvent")
+
     qDebug() << this << "::logEvent" << event << "long long param" << param << ":" << value;
     analytics::LogEvent(event.toUtf8().constData(), param.toUtf8().constData(), static_cast<int64_t>(value));
 }
 
 void QtFirebaseAnalytics::logEvent(const QString &event, const QString &param, double value)
 {
+    if (!_ready)
+        _cache << [ this, event, param, value ] { logEvent(event, param, value); };
     QTFIREBASE_ANALYTICS_CHECK_READY("::logEvent")
+
     qDebug() << this << "::logEvent" << event << "double param" << param << ":" << value;
     analytics::LogEvent(event.toUtf8().constData(), param.toUtf8().constData(), value);
 }
 
 void QtFirebaseAnalytics::logEvent(const QString &event, const QString &param, const QString &value)
 {
+    if (!_ready)
+        _cache << [ this, event, param, value ] { logEvent(event, param, value); };
     QTFIREBASE_ANALYTICS_CHECK_READY("::logEvent")
+
     qDebug() << this << "::logEvent" << event << "string param" << param << ":" << value;
     analytics::LogEvent(event.toUtf8().constData(), param.toUtf8().constData(), value.toUtf8().constData());
 }
 
 void QtFirebaseAnalytics::logEvent(const QString &event, const QVariantMap &bundle)
 {
+    if (!_ready)
+        _cache << [ this, event, bundle ] { logEvent(event, bundle); };
     QTFIREBASE_ANALYTICS_CHECK_READY("::logEvent")
 
     qDebug().noquote() << this << "::logEvent bundle" << event;

--- a/src/qtfirebaseanalytics.cpp
+++ b/src/qtfirebaseanalytics.cpp
@@ -5,6 +5,12 @@
 #include <QVector>
 #include <QDebug>
 
+#define QTFIREBASE_ANALYTICS_CHECK_READY(name) \
+    if (!_ready) { \
+        qDebug().noquote() << this << name << "native part not ready"; \
+        return; \
+    }
+
 const int USER_ID_MAX_LEN { 256 };
 
 namespace analytics = firebase::analytics;
@@ -63,11 +69,7 @@ void QtFirebaseAnalytics::setReady(bool ready)
 
 void QtFirebaseAnalytics::setEnabled(bool enabled)
 {
-    if (!_ready) {
-        qDebug() << this << "::setEnabled native part not ready";
-        return;
-    }
-
+    QTFIREBASE_ANALYTICS_CHECK_READY("::setEnabled")
     if (_enabled == enabled)
         return;
 
@@ -81,11 +83,7 @@ void QtFirebaseAnalytics::setEnabled(bool enabled)
 void QtFirebaseAnalytics::setMinimumSessionDuration(uint minimumSessionDuration)
 {
     qWarning() << this << "::setMinimumSessionDuration is deprecated and no longer functional";
-    if (!_ready) {
-        qDebug() << this << "::setMinimumSessionDuration native part not ready";
-        return;
-    }
-
+    QTFIREBASE_ANALYTICS_CHECK_READY("::setMinimumSessionDuration")
     if (_minimumSessionDuration == minimumSessionDuration)
         return;
 
@@ -96,11 +94,7 @@ void QtFirebaseAnalytics::setMinimumSessionDuration(uint minimumSessionDuration)
 
 void QtFirebaseAnalytics::setSessionTimeout(uint sessionTimeout)
 {
-    if (!_ready) {
-        qDebug() << this << "::setSessionTimeout native part not ready";
-        return;
-    }
-
+    QTFIREBASE_ANALYTICS_CHECK_READY("::setSessionTimeout")
     if (_sessionTimeout == sessionTimeout)
         return;
 
@@ -113,10 +107,8 @@ void QtFirebaseAnalytics::setSessionTimeout(uint sessionTimeout)
 
 void QtFirebaseAnalytics::setUserId(const QString &userId)
 {
-    if (!_ready) {
-        qDebug() << this << "::setUserId native part not ready";
-        return;
-    }
+    QTFIREBASE_ANALYTICS_CHECK_READY("::setUserId")
+
     if (userId.isEmpty())
         return unsetUserId();
 
@@ -137,11 +129,7 @@ void QtFirebaseAnalytics::setUserId(const QString &userId)
 
 void QtFirebaseAnalytics::setUserProperties(const QVariantList &userProperties)
 {
-    if (!_ready) {
-        qDebug() << this << "::setUserProperties native part not ready";
-        return;
-    }
-
+    QTFIREBASE_ANALYTICS_CHECK_READY("::setUserProperties")
     if (_userProperties == userProperties)
         return;
     _userProperties = userProperties;
@@ -171,20 +159,14 @@ void QtFirebaseAnalytics::setUserProperties(const QVariantList &userProperties)
 
 void QtFirebaseAnalytics::setUserProperty(const QString &name, const QString &value)
 {
-    if (!_ready) {
-        qDebug() << this << "::setUserProperty native part not ready";
-        return;
-    }
+    QTFIREBASE_ANALYTICS_CHECK_READY("::setUserProperty")
     qDebug() << this << "::setUserProperty" << name << ":" << value;
     analytics::SetUserProperty(name.toUtf8().constData(), value.toUtf8().constData());
 }
 
 void QtFirebaseAnalytics::unsetUserId()
 {
-    if (!_ready) {
-        qDebug() << this << "::unsetUserId native part not ready";
-        return;
-    }
+    QTFIREBASE_ANALYTICS_CHECK_READY("::unsetUserId")
 
     if (_userId.isEmpty())
         return;
@@ -197,10 +179,7 @@ void QtFirebaseAnalytics::unsetUserId()
 void QtFirebaseAnalytics::setCurrentScreen(const QString &screenName, const QString &screenClass)
 {
     qWarning() << this << "::setCurrentScreen is deprecated";
-    if (!_ready) {
-        qDebug() << this << "::setCurrentScreen native part not ready";
-        return;
-    }
+    QTFIREBASE_ANALYTICS_CHECK_READY("::setCurrentScreen")
     qDebug() << this << "::setCurrentScreen" << screenName << ":" << screenClass;
     analytics::SetCurrentScreen(screenName.toUtf8().constData(), screenClass.toUtf8().constData());
 }
@@ -208,50 +187,36 @@ void QtFirebaseAnalytics::setCurrentScreen(const QString &screenName, const QStr
 
 void QtFirebaseAnalytics::logEvent(const QString &name)
 {
-    if (!_ready) {
-        qDebug() << this << "::logEvent native part not ready";
-        return;
-    }
+    QTFIREBASE_ANALYTICS_CHECK_READY("::logEvent")
     qDebug() << this << "::logEvent" << name << "(no params)";
     analytics::LogEvent(name.toUtf8().constData());
 }
 
 void QtFirebaseAnalytics::logEvent(const QString &name, const QString &param, int value)
 {
-    if (!_ready) {
-        qDebug() << this << "::logEvent native part not ready";
-        return;
-    }
+    QTFIREBASE_ANALYTICS_CHECK_READY("::logEvent")
     qDebug() << this << "::logEvent" << name << "int param" << param << ":" << value;
     analytics::LogEvent(name.toUtf8().constData(), param.toUtf8().constData(), value);
 }
 
 void QtFirebaseAnalytics::logEvent(const QString &name, const QString &param, double value)
 {
-    if (!_ready) {
-        qDebug() << this << "::logEvent native part not ready";
-        return;
-    }
+    QTFIREBASE_ANALYTICS_CHECK_READY("::logEvent")
     qDebug() << this << "::logEvent" << name << "double param" << param << ":" << value;
     analytics::LogEvent(name.toUtf8().constData(), param.toUtf8().constData(), value);
 }
 
 void QtFirebaseAnalytics::logEvent(const QString &name, const QString &param, const QString &value)
 {
-    if (!_ready) {
-        qDebug() << this << "::logEvent native part not ready";
-        return;
-    }
+    QTFIREBASE_ANALYTICS_CHECK_READY("::logEvent")
     qDebug() << this << "::logEvent" << name << "string param" << param << ":" << value;
     analytics::LogEvent(name.toUtf8().constData(), param.toUtf8().constData(), value.toUtf8().constData());
 }
 
 void QtFirebaseAnalytics::logEvent(const QString &name, const QVariantMap &bundle)
 {
-    if (!_ready) {
-        qDebug() << this << "::logEvent native part not ready";
-        return;
-    }
+    QTFIREBASE_ANALYTICS_CHECK_READY("::logEvent")
+
     qDebug().noquote() << this << "::logEvent bundle" << name;
 
     QVector<analytics::Parameter> parameters;

--- a/src/qtfirebaseanalytics.cpp
+++ b/src/qtfirebaseanalytics.cpp
@@ -5,6 +5,8 @@
 #include <QVector>
 #include <QDebug>
 
+const int USER_ID_MAX_LEN { 256 };
+
 namespace analytics = firebase::analytics;
 
 QtFirebaseAnalytics *QtFirebaseAnalytics::self { nullptr };
@@ -119,9 +121,9 @@ void QtFirebaseAnalytics::setUserId(const QString &userId)
         return unsetUserId();
 
     auto aUserId = userId;
-    if (aUserId.length() > 36) {
-        aUserId = aUserId.left(36);
-        qWarning() << this << "::setUserId" << "ID longer than allowed 36 chars" << "TRUNCATED to" << aUserId;
+    if (aUserId.length() > USER_ID_MAX_LEN) {
+        aUserId = aUserId.left(USER_ID_MAX_LEN);
+        qWarning() << this << QStringLiteral("::setUserId ID longer than allowed %1 chars and truncated to").arg(USER_ID_MAX_LEN) << aUserId;
     }
     if (_userId == aUserId)
         return;

--- a/src/qtfirebaseanalytics.h
+++ b/src/qtfirebaseanalytics.h
@@ -61,12 +61,12 @@ public slots:
     void setCurrentScreen(const QString &screenName, const QString &screenClass);
 #endif
 
-    void logEvent(const QString &name);
-    void logEvent(const QString &name, const QString &param, int value);
-    void logEvent(const QString &name, const QString &param, long long value);
-    void logEvent(const QString &name, const QString &param, double value);
-    void logEvent(const QString &name, const QString &param, const QString &value);
-    void logEvent(const QString &name, const QVariantMap &bundle);
+    void logEvent(const QString &event);
+    void logEvent(const QString &event, const QString &param, int value);
+    void logEvent(const QString &event, const QString &param, long long value);
+    void logEvent(const QString &event, const QString &param, double value);
+    void logEvent(const QString &event, const QString &param, const QString &value);
+    void logEvent(const QString &event, const QVariantMap &bundle);
 
 signals:
     void readyChanged();
@@ -79,12 +79,9 @@ signals:
 private slots:
     void init();
 private:
-    QString fixStringLength(const QString &str, uint maxLength, const char *func, const char *name) const;
-    QString fixStringLength(const QString &str, uint maxLength, const char *func, const QByteArray &name) const {
-        return fixStringLength(str, maxLength, func, name.constData());
-    }
     bool checkEventName(QString &fixed, const QString &name) const;
     bool checkParamName(QString &fixed, const QString &name) const;
+    QString fixStringLength(const QString &str, int maxLength, const char *func, const char *name) const;
 private:
 
     bool _ready = false;

--- a/src/qtfirebaseanalytics.h
+++ b/src/qtfirebaseanalytics.h
@@ -79,6 +79,7 @@ private slots:
     void init();
 private:
     bool checkEventName(QString &fixed, const QString &name) const;
+    bool checkParamName(QString &fixed, const QString &name) const;
 private:
 
     bool _ready = false;

--- a/src/qtfirebaseanalytics.h
+++ b/src/qtfirebaseanalytics.h
@@ -78,6 +78,8 @@ signals:
 private slots:
     void init();
 private:
+    bool checkEventName(QString &fixed, const QString &name) const;
+private:
 
     bool _ready = false;
     bool _enabled = false;

--- a/src/qtfirebaseanalytics.h
+++ b/src/qtfirebaseanalytics.h
@@ -5,65 +5,67 @@
 
 #include "src/qtfirebase.h"
 
-#if defined(qFirebaseAnalytics)
-#undef qFirebaseAnalytics
-#endif
-#define qFirebaseAnalytics (static_cast<QtFirebaseAnalytics *>(QtFirebaseAnalytics::instance()))
-
-#include "firebase/analytics.h"
-#include "firebase/analytics/event_names.h"
-#include "firebase/analytics/parameter_names.h"
-#include "firebase/analytics/user_property_names.h"
-
-#include <QDebug>
 #include <QObject>
 #include <QVariantMap>
 #include <QVariantList>
 
+#if defined(qFirebaseAnalytics)
+#undef qFirebaseAnalytics
+#endif
+#define qFirebaseAnalytics (QtFirebaseAnalytics::instance())
+
 class QtFirebaseAnalytics : public QObject
 {
     Q_OBJECT
+    Q_DISABLE_COPY(QtFirebaseAnalytics)
 
     Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
     Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
-
-    Q_PROPERTY(unsigned int minimumSessionDuration READ minimumSessionDuration WRITE setMinimumSessionDuration NOTIFY minimumSessionDurationChanged)
-    Q_PROPERTY(unsigned int sessionTimeout READ sessionTimeout WRITE setSessionTimeout NOTIFY sessionTimeoutChanged)
-
+    Q_PROPERTY(uint minimumSessionDuration READ minimumSessionDuration WRITE setMinimumSessionDuration NOTIFY minimumSessionDurationChanged)
+    Q_PROPERTY(uint sessionTimeout READ sessionTimeout WRITE setSessionTimeout NOTIFY sessionTimeoutChanged)
     Q_PROPERTY(QString userId READ userId WRITE setUserId NOTIFY userIdChanged)
     Q_PROPERTY(QVariantList userProperties READ userProperties WRITE setUserProperties NOTIFY userPropertiesChanged)
 
+    static QtFirebaseAnalytics *self;
 public:
-    explicit QtFirebaseAnalytics(QObject* parent = nullptr);
-    ~QtFirebaseAnalytics();
-
-    static QtFirebaseAnalytics *instance() {
-        if(!self) {
-            self = new QtFirebaseAnalytics();
-            qDebug() << self << "::instance" << "singleton";
-        }
+    static QtFirebaseAnalytics *instance(QObject *parent = nullptr) {
+        if (!self)
+            self = new QtFirebaseAnalytics(parent);
         return self;
     }
 
-    bool checkInstance(const char *function);
+    static bool checkInstance(const char *function = nullptr) { Q_UNUSED(function) return self; }
 
-    bool ready();
-    void setReady(bool ready);
+    explicit QtFirebaseAnalytics(QObject *parent = nullptr);
+    virtual ~QtFirebaseAnalytics();
 
-    bool enabled();
-    void setEnabled(bool enabled);
+    bool ready() const { return _ready; }
+    bool enabled() const { return _enabled; }
+    uint minimumSessionDuration() const { return _minimumSessionDuration; }
+    uint sessionTimeout() const { return _sessionTimeout; }
+    QString userId() const { return _userId; }
+    QVariantList userProperties() const { return _userProperties; }
 
-    unsigned int minimumSessionDuration();
-    void setMinimumSessionDuration(unsigned int minimumSessionDuration);
+    void setReady(bool = true);
+    void setEnabled(bool = true);
+    void setMinimumSessionDuration(uint);
+    void setSessionTimeout(uint);
+    void setUserId(const QString &);
+    void setUserProperties(const QVariantList &);
+public slots:
+    void setUserProperty(const QString &name, const QString &value);
 
-    unsigned int sessionTimeout() const;
-    void setSessionTimeout(unsigned int sessionTimeout);
+    void unsetUserId();
 
-    QString userId() const;
-    Q_INVOKABLE void unsetUserId();
+#if QTFIREBASE_FIREBASE_VERSION < QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
+    void setCurrentScreen(const QString &screenName, const QString &screenClass);
+#endif
 
-    QVariantList userProperties() const;
-    void setUserProperties(const QVariantList &userProperties);
+    void logEvent(const QString &name);
+    void logEvent(const QString &name, const QString &param, int value);
+    void logEvent(const QString &name, const QString &param, double value);
+    void logEvent(const QString &name, const QString &param, const QString &value);
+    void logEvent(const QString &name, const QVariantMap &bundle);
 
 signals:
     void readyChanged();
@@ -73,35 +75,15 @@ signals:
     void userIdChanged();
     void userPropertiesChanged();
 
-public slots:
-    void setUserId(const QString &userId);
-    void setUserProperty(const QString &propertyName, const QString &propertyValue);
-#if QTFIREBASE_FIREBASE_VERSION < QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
-    void setCurrentScreen(const QString &screenName, const QString &screenClass);
-#endif
-    void logEvent(const QString &name);
-    void logEvent(const QString &name, const QString &parameterName, const QString &parameterValue);
-    void logEvent(const QString &name, const QString &parameterName, const double parameterValue);
-    void logEvent(const QString &name, const QString &parameterName, const int parameterValue);
-    void logEvent(const QString &name, const QVariantMap &bundle);
-    //void logEvent(const QString &name, const QString &parameterName, const int64_t parameterValue);
-
 private slots:
     void init();
-
 private:
-    static QtFirebaseAnalytics *self;
-    Q_DISABLE_COPY(QtFirebaseAnalytics)
 
-    bool _ready;
-    bool _initializing;
-
-    bool _enabled;
-    unsigned int _minimumSessionDuration;
-    unsigned int _sessionTimeout;
-
+    bool _ready = false;
+    bool _enabled = false;
+    uint _minimumSessionDuration = 0;
+    uint _sessionTimeout = 1800000;
     QString _userId;
-
     QVariantList _userProperties;
 };
 

--- a/src/qtfirebaseanalytics.h
+++ b/src/qtfirebaseanalytics.h
@@ -20,6 +20,7 @@ class QtFirebaseAnalytics : public QObject
     Q_DISABLE_COPY(QtFirebaseAnalytics)
 
     Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
+
     Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
     Q_PROPERTY(uint minimumSessionDuration READ minimumSessionDuration WRITE setMinimumSessionDuration NOTIFY minimumSessionDurationChanged)
     Q_PROPERTY(uint sessionTimeout READ sessionTimeout WRITE setSessionTimeout NOTIFY sessionTimeoutChanged)
@@ -46,15 +47,13 @@ public:
     QString userId() const { return _userId; }
     QVariantList userProperties() const { return _userProperties; }
 
-    void setReady(bool = true);
     void setEnabled(bool = true);
     void setMinimumSessionDuration(uint);
-    void setSessionTimeout(uint);
+    void setSessionTimeout(uint ms);
     void setUserId(const QString &);
     void setUserProperties(const QVariantList &);
 public slots:
     void setUserProperty(const QString &name, const QString &value);
-
     void unsetUserId();
 
 #if QTFIREBASE_FIREBASE_VERSION < QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
@@ -79,6 +78,8 @@ signals:
 private slots:
     void init();
 private:
+    void setReady(bool = true);
+
     bool checkEventName(QString &fixed, const QString &name) const;
     bool checkParamName(QString &fixed, const QString &name) const;
     QString fixStringLength(const QString &str, int maxLength, const char *func, const char *name) const;

--- a/src/qtfirebaseanalytics.h
+++ b/src/qtfirebaseanalytics.h
@@ -79,10 +79,6 @@ private slots:
     void init();
 private:
     void setReady(bool = true);
-
-    bool checkEventName(QString &fixed, const QString &name) const;
-    bool checkParamName(QString &fixed, const QString &name) const;
-    QString fixStringLength(const QString &str, int maxLength, const char *func, const char *name) const;
 private:
 
     bool _ready = false;

--- a/src/qtfirebaseanalytics.h
+++ b/src/qtfirebaseanalytics.h
@@ -9,6 +9,8 @@
 #include <QVariantMap>
 #include <QVariantList>
 
+#include <functional>
+
 #if defined(qFirebaseAnalytics)
 #undef qFirebaseAnalytics
 #endif
@@ -77,6 +79,7 @@ signals:
 
 private slots:
     void init();
+    void processCache();
 private:
     void setReady(bool = true);
 private:
@@ -87,6 +90,8 @@ private:
     uint _sessionTimeout = 1800000;
     QString _userId;
     QVariantList _userProperties;
+
+    QList<std::function<void()> > _cache;
 };
 
 #endif // QTFIREBASE_BUILD_ANALYTICS

--- a/src/qtfirebaseanalytics.h
+++ b/src/qtfirebaseanalytics.h
@@ -63,6 +63,7 @@ public slots:
 
     void logEvent(const QString &name);
     void logEvent(const QString &name, const QString &param, int value);
+    void logEvent(const QString &name, const QString &param, long long value);
     void logEvent(const QString &name, const QString &param, double value);
     void logEvent(const QString &name, const QString &param, const QString &value);
     void logEvent(const QString &name, const QVariantMap &bundle);

--- a/src/qtfirebaseanalytics.h
+++ b/src/qtfirebaseanalytics.h
@@ -78,6 +78,10 @@ signals:
 private slots:
     void init();
 private:
+    QString fixStringLength(const QString &str, uint maxLength, const char *func, const char *name) const;
+    QString fixStringLength(const QString &str, uint maxLength, const char *func, const QByteArray &name) const {
+        return fixStringLength(str, maxLength, func, name.constData());
+    }
     bool checkEventName(QString &fixed, const QString &name) const;
     bool checkParamName(QString &fixed, const QString &name) const;
 private:

--- a/stub/src/qtfirebaseanalytics.h
+++ b/stub/src/qtfirebaseanalytics.h
@@ -3,58 +3,68 @@
 
 #ifdef QTFIREBASE_BUILD_ANALYTICS
 
-#include "qtfirebase.h"
-
-#if defined(qFirebaseAnalytics)
-#undef qFirebaseAnalytics
-#endif
-#define qFirebaseAnalytics (static_cast<QtFirebaseAnalytics *>(QtFirebaseAnalytics::instance()))
+#include "src/qtfirebase.h"
 
 #include <QObject>
 #include <QVariantMap>
 #include <QVariantList>
 
+#if defined(qFirebaseAnalytics)
+#undef qFirebaseAnalytics
+#endif
+#define qFirebaseAnalytics (QtFirebaseAnalytics::instance())
+
 class QtFirebaseAnalytics : public QObject
 {
     Q_OBJECT
+    Q_DISABLE_COPY(QtFirebaseAnalytics)
 
     Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
+
     Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
-
-    Q_PROPERTY(unsigned int minimumSessionDuration READ minimumSessionDuration WRITE setMinimumSessionDuration NOTIFY minimumSessionDurationChanged)
-    Q_PROPERTY(unsigned int sessionTimeout READ sessionTimeout WRITE setSessionTimeout NOTIFY sessionTimeoutChanged)
-
+    Q_PROPERTY(uint minimumSessionDuration READ minimumSessionDuration WRITE setMinimumSessionDuration NOTIFY minimumSessionDurationChanged)
+    Q_PROPERTY(uint sessionTimeout READ sessionTimeout WRITE setSessionTimeout NOTIFY sessionTimeoutChanged)
     Q_PROPERTY(QString userId READ userId WRITE setUserId NOTIFY userIdChanged)
     Q_PROPERTY(QVariantList userProperties READ userProperties WRITE setUserProperties NOTIFY userPropertiesChanged)
-public:
-    explicit QtFirebaseAnalytics(QObject* parent = nullptr) { Q_UNUSED(parent) }
-    ~QtFirebaseAnalytics() {}
 
-    static QtFirebaseAnalytics *instance() {
-        if(!self) {
-            self = new QtFirebaseAnalytics();
-        }
+    static QtFirebaseAnalytics *self;
+public:
+    static QtFirebaseAnalytics *instance(QObject *parent = nullptr) {
+        if (!self)
+            self = new QtFirebaseAnalytics(parent);
         return self;
     }
-    bool checkInstance(const char *function) { Q_UNUSED(function) return false; }
 
-    bool ready() { return false; }
-    void setReady(bool ready) { Q_UNUSED(ready) }
+    static bool checkInstance(const char *function = nullptr) { Q_UNUSED(function) return self; }
 
-    bool enabled() { return false; }
-    void setEnabled(bool enabled) { Q_UNUSED(enabled) }
+    explicit QtFirebaseAnalytics(QObject *parent = nullptr) : QObject(parent) { }
 
-    unsigned int minimumSessionDuration() { return 0; }
-    void setMinimumSessionDuration(unsigned int minimumSessionDuration) { Q_UNUSED(minimumSessionDuration) }
-
-    unsigned int sessionTimeout() const { return 0; }
-    void setSessionTimeout(unsigned int sessionTimeout) { Q_UNUSED(sessionTimeout) }
-
-    QString userId() const { return QStringLiteral(""); }
-    Q_INVOKABLE void unsetUserId() {}
-
+    bool ready() const { return false; }
+    bool enabled() const { return false; }
+    uint minimumSessionDuration() const { return 0; }
+    uint sessionTimeout() const { return 0; }
+    QString userId() const { return QString(); }
     QVariantList userProperties() const { return QVariantList(); }
-    void setUserProperties(const QVariantList &userProperties) { Q_UNUSED(userProperties) }
+
+    void setEnabled(bool = true) { }
+    void setMinimumSessionDuration(uint) { }
+    void setSessionTimeout(uint) { }
+    void setUserId(const QString &) { }
+    void setUserProperties(const QVariantList &) { }
+public slots:
+    void setUserProperty(const QString &, const QString &) { }
+    void unsetUserId() { }
+
+#if QTFIREBASE_FIREBASE_VERSION < QTFIREBASE_FIREBASE_VERSION_CHECK(8, 0, 0)
+    void setCurrentScreen(const QString &, const QString &) { }
+#endif
+
+    void logEvent(const QString &) { }
+    void logEvent(const QString &, const QString &, int) { }
+    void logEvent(const QString &, const QString &, long long) { }
+    void logEvent(const QString &, const QString &, double) { }
+    void logEvent(const QString &, const QString &, const QString &) { }
+    void logEvent(const QString &, const QVariantMap &) { }
 
 signals:
     void readyChanged();
@@ -63,20 +73,6 @@ signals:
     void sessionTimeoutChanged();
     void userIdChanged();
     void userPropertiesChanged();
-
-public slots:
-    void setUserId(const QString &userId) { Q_UNUSED(userId) }
-    void setUserProperty(const QString &propertyName, const QString &propertyValue) { Q_UNUSED(propertyName) Q_UNUSED(propertyValue) }
-    void setCurrentScreen(const QString &screenName, const QString &screenClass) { Q_UNUSED(screenName) Q_UNUSED(screenClass) }
-    void logEvent(const QString &name) { Q_UNUSED(name) }
-    void logEvent(const QString &name, const QString &parameterName, const QString &parameterValue) { Q_UNUSED(name) Q_UNUSED(parameterName) Q_UNUSED(parameterValue) }
-    void logEvent(const QString &name, const QString &parameterName, const double parameterValue) { Q_UNUSED(name) Q_UNUSED(parameterName) Q_UNUSED(parameterValue) }
-    void logEvent(const QString &name, const QString &parameterName, const int parameterValue) { Q_UNUSED(name) Q_UNUSED(parameterName) Q_UNUSED(parameterValue) }
-    void logEvent(const QString &name, const QVariantMap bundle) { Q_UNUSED(name) Q_UNUSED(bundle) }
-
-private:
-    static QtFirebaseAnalytics *self;
-    Q_DISABLE_COPY(QtFirebaseAnalytics)
 };
 
 #endif // QTFIREBASE_BUILD_ANALYTICS


### PR DESCRIPTION
1. Fixed that ```readyChanged``` signal might not be emitted.
2. Added support for ```long long``` type.
3. Added cache to save events until the instance is ready.
4. Removed truncation of user ID because there was wrong limit of 36 (actually 256).

_At first I added all the validation rules at the Qt layer, but then I decided to delegate this work to Firebase CPP SDK only, since it also prints debug messages._